### PR TITLE
feat(pack): modularizeImport plugin support handleDefaultImport & handleNamespaceImport config

### DIFF
--- a/crates/pack-core/src/shared/transforms/modularize_imports.rs
+++ b/crates/pack-core/src/shared/transforms/modularize_imports.rs
@@ -30,6 +30,10 @@ pub struct ModularizeImportPackageConfig {
     pub prevent_full_import: bool,
     #[serde(default)]
     pub skip_default_conversion: bool,
+    #[serde(default)]
+    pub handle_default_import: bool,
+    #[serde(default)]
+    pub handle_namespace_import: bool,
 }
 
 #[derive(
@@ -97,8 +101,8 @@ impl ModularizeImportsTransformer {
                                 },
                                 prevent_full_import: v.prevent_full_import,
                                 skip_default_conversion: v.skip_default_conversion,
-                                handle_default_import: false,
-                                handle_namespace_import: false,
+                                handle_default_import: v.handle_default_import,
+                                handle_namespace_import: v.handle_namespace_import,
                             }),
                         )
                     })

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -241,7 +241,7 @@ pub struct SchemaOptimizationConfig {
     /// Modularize imports configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(description = "Modularize imports configuration")]
-    pub modularize_imports: Option<HashMap<String, serde_json::Value>>,
+    pub modularize_imports: Option<HashMap<String, SchemaModularizeImportPackageConfig>>,
 
     /// Whether to concatenate modules when possible to reduce the number of chunks
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -258,6 +258,46 @@ pub enum SchemaModuleIds {
     Named,
     Deterministic,
 }
+
+/// Transform configuration for modularize imports
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum SchemaTransform {
+    /// String transform template
+    String(String),
+    /// Vector of transformation pairs
+    Vec(Vec<(String, String)>),
+}
+
+/// Modularize import package configuration
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaModularizeImportPackageConfig {
+    /// Transform configuration
+    #[schemars(description = "Transform configuration")]
+    pub transform: SchemaTransform,
+    
+    /// Prevent full import of the package
+    #[serde(default)]
+    #[schemars(description = "Prevent full import of the package")]
+    pub prevent_full_import: bool,
+    
+    /// Skip default conversion
+    #[serde(default)]
+    #[schemars(description = "Skip default conversion")]
+    pub skip_default_conversion: bool,
+    
+    /// Handle default import
+    #[serde(default)]
+    #[schemars(description = "Handle default import")]
+    pub handle_default_import: bool,
+    
+    /// Handle namespace import
+    #[serde(default)]
+    #[schemars(description = "Handle namespace import")]
+    pub handle_namespace_import: bool,
+}
+
 
 /// Console removal configuration
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -7,6 +7,7 @@ import styles from './index.module.less';
 export function App() {
   return <>
     <h1 className={styles.pre}>App2 {foo} - HMR Test by {dataText}</h1>
+    <h1>React Version is: {React.version}</h1>
     <Person />
   </>;
 }

--- a/examples/react/src/index.tsx
+++ b/examples/react/src/index.tsx
@@ -7,4 +7,5 @@ let x: TypeA<string> = { content: 'wd' };
 
 x;
 
+
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -553,6 +553,43 @@
         }
       }
     },
+    "SchemaModularizeImportPackageConfig": {
+      "description": "Modularize import package configuration",
+      "type": "object",
+      "required": [
+        "transform"
+      ],
+      "properties": {
+        "handleDefaultImport": {
+          "description": "Handle default import",
+          "default": false,
+          "type": "boolean"
+        },
+        "handleNamespaceImport": {
+          "description": "Handle namespace import",
+          "default": false,
+          "type": "boolean"
+        },
+        "preventFullImport": {
+          "description": "Prevent full import of the package",
+          "default": false,
+          "type": "boolean"
+        },
+        "skipDefaultConversion": {
+          "description": "Skip default conversion",
+          "default": false,
+          "type": "boolean"
+        },
+        "transform": {
+          "description": "Transform configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SchemaTransform"
+            }
+          ]
+        }
+      }
+    },
     "SchemaModuleConfig": {
       "description": "Module configuration",
       "type": "object",
@@ -609,7 +646,9 @@
             "object",
             "null"
           ],
-          "additionalProperties": true
+          "additionalProperties": {
+            "$ref": "#/definitions/SchemaModularizeImportPackageConfig"
+          }
         },
         "moduleIds": {
           "description": "Module ID generation strategy",
@@ -856,6 +895,32 @@
           "description": "Styled components configuration"
         }
       }
+    },
+    "SchemaTransform": {
+      "description": "Transform configuration for modularize imports",
+      "anyOf": [
+        {
+          "description": "String transform template",
+          "type": "string"
+        },
+        {
+          "description": "Vector of transformation pairs",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2
+          }
+        }
+      ]
     }
   }
 }

--- a/packages/pack/src/webpackCompat.ts
+++ b/packages/pack/src/webpackCompat.ts
@@ -420,7 +420,7 @@ function compatOptimization(
   const {
     moduleIds,
     minimize,
-    // TODO: concatenateModules to be supported, need to upgrade to next.js@15.4
+    concatenateModules,
   } = webpackOptimization;
   return {
     moduleIds:
@@ -430,6 +430,7 @@ function compatOptimization(
           ? "deterministic"
           : undefined,
     minify: minimize,
+    concatenateModules,
   };
 }
 


### PR DESCRIPTION
## Summary

part of: https://github.com/utooland/utoo/issues/2165

把 default import 和 namespace import 的开关开放先，后续还需要添加一个 style 的配置(需要先把 swc 升级上来)，用于处理样式文件的导入。


## Test Plan

等 `style` 添加了构造一组快照测试出来。
