### PR TITLE
feat(pack): support modularizeImports style

### DIFF
--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -296,6 +296,11 @@ pub struct SchemaModularizeImportPackageConfig {
     #[serde(default)]
     #[schemars(description = "Handle namespace import")]
     pub handle_namespace_import: bool,
+
+    /// Style import configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "Style import configuration")]
+    pub style: Option<String>,
 }
 
 /// Console removal configuration

--- a/crates/pack-tests/tests/snapshot/node_modules/antd/es/date-picker/style/index.js
+++ b/crates/pack-tests/tests/snapshot/node_modules/antd/es/date-picker/style/index.js
@@ -1,0 +1,1 @@
+export default "date-picker-style";

--- a/crates/pack-tests/tests/snapshot/optimization/modularize_imports/config.json
+++ b/crates/pack-tests/tests/snapshot/optimization/modularize_imports/config.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.js",
+        "name": "main"
+      }
+    ],
+    "optimization": {
+      "modularizeImports": {
+        "antd": {
+          "transform": "antd/es/{{ kebabCase member }}",
+          "preventFullImport": false,
+          "skipDefaultConversion": false,
+          "style": "style"
+        }
+      },
+      "moduleIds": "named",
+      "minify": false
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/optimization/modularize_imports/input/index.js
+++ b/crates/pack-tests/tests/snapshot/optimization/modularize_imports/input/index.js
@@ -1,0 +1,4 @@
+import { Button, DatePicker } from "antd";
+
+console.log(Button);
+console.log(DatePicker);

--- a/crates/pack-tests/tests/snapshot/optimization/modularize_imports/output/crates_pack-tests_tests_snapshot_b5b07607.js
+++ b/crates/pack-tests/tests/snapshot/optimization/modularize_imports/output/crates_pack-tests_tests_snapshot_b5b07607.js
@@ -1,0 +1,59 @@
+(globalThis.TURBOPACK || (globalThis.TURBOPACK = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/crates/pack-tests/tests/snapshot/node_modules/antd/es/button/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([
+    "default",
+    ()=>Button
+]);
+function Button() {
+    return "button";
+}
+}),
+"[project]/crates/pack-tests/tests/snapshot/node_modules/antd/es/button/style/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([
+    "default",
+    ()=>__TURBOPACK__default__export__
+]);
+const __TURBOPACK__default__export__ = "button-style";
+}),
+"[project]/crates/pack-tests/tests/snapshot/node_modules/antd/es/date-picker/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([
+    "default",
+    ()=>DatePicker
+]);
+function DatePicker() {
+    return "date-picker";
+}
+}),
+"[project]/crates/pack-tests/tests/snapshot/node_modules/antd/es/date-picker/style/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([
+    "default",
+    ()=>__TURBOPACK__default__export__
+]);
+const __TURBOPACK__default__export__ = "date-picker-style";
+}),
+"[project]/crates/pack-tests/tests/snapshot/optimization/modularize_imports/input/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([]);
+var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$pack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f$antd$2f$es$2f$button$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/crates/pack-tests/tests/snapshot/node_modules/antd/es/button/index.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$pack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f$antd$2f$es$2f$button$2f$style$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/crates/pack-tests/tests/snapshot/node_modules/antd/es/button/style/index.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$pack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f$antd$2f$es$2f$date$2d$picker$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/crates/pack-tests/tests/snapshot/node_modules/antd/es/date-picker/index.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$pack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f$antd$2f$es$2f$date$2d$picker$2f$style$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/crates/pack-tests/tests/snapshot/node_modules/antd/es/date-picker/style/index.js [client] (ecmascript)");
+;
+;
+;
+;
+console.log(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$pack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f$antd$2f$es$2f$button$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__["default"]);
+console.log(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$pack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f$antd$2f$es$2f$date$2d$picker$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__["default"]);
+}),
+]);
+
+//# sourceMappingURL=crates_pack-tests_tests_snapshot_b5b07607.js.map

--- a/crates/pack-tests/tests/snapshot/optimization/modularize_imports/output/crates_pack-tests_tests_snapshot_b5b07607.js.map
+++ b/crates/pack-tests/tests/snapshot/optimization/modularize_imports/output/crates_pack-tests_tests_snapshot_b5b07607.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/node_modules/antd/es/button/index.js"],"sourcesContent":["export default function Button() {\n    return \"button\";\n}"],"names":[],"mappings":";;;;AAAe,SAAS;IACpB,OAAO;AACX","ignoreList":[0]}},
+    {"offset": {"line": 15, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/node_modules/antd/es/button/style/index.js"],"sourcesContent":["export default \"button-style\";"],"names":[],"mappings":";;;;uCAAe","ignoreList":[0]}},
+    {"offset": {"line": 24, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/node_modules/antd/es/date-picker/index.js"],"sourcesContent":["export default function DatePicker() {\n    return \"date-picker\";\n}"],"names":[],"mappings":";;;;AAAe,SAAS;IACpB,OAAO;AACX","ignoreList":[0]}},
+    {"offset": {"line": 35, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/node_modules/antd/es/date-picker/style/index.js"],"sourcesContent":["export default \"date-picker-style\";"],"names":[],"mappings":";;;;uCAAe","ignoreList":[0]}},
+    {"offset": {"line": 44, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/optimization/modularize_imports/input/index.js"],"sourcesContent":["import { Button, DatePicker } from \"antd\";\n\nconsole.log(Button);\nconsole.log(DatePicker);"],"names":[],"mappings":";AAAA;AAAA;AAAA;AAAA;;;;;AAEA,QAAQ,GAAG,CAAC,oMAAM;AAClB,QAAQ,GAAG,CAAC,4MAAU"}}]
+}

--- a/crates/pack-tests/tests/snapshot/optimization/modularize_imports/output/main.js
+++ b/crates/pack-tests/tests/snapshot/optimization/modularize_imports/output/main.js
@@ -1,0 +1,5 @@
+(globalThis.TURBOPACK || (globalThis.TURBOPACK = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["crates_pack-tests_tests_snapshot_b5b07607.js"],"runtimeModuleIds":["[project]/crates/pack-tests/tests/snapshot/optimization/modularize_imports/input/index.js [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/optimization/modularize_imports/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/optimization/modularize_imports/output/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/optimization/remove_console/config.json
+++ b/crates/pack-tests/tests/snapshot/optimization/remove_console/config.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.js",
+        "name": "main"
+      }
+    ],
+    "optimization": {
+      "minify": false,
+      "removeConsole": {
+        "exclude": ["error"]
+      }
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/optimization/remove_console/input/index.js
+++ b/crates/pack-tests/tests/snapshot/optimization/remove_console/input/index.js
@@ -1,0 +1,4 @@
+export function main() {
+    console.log("LOG MSG");
+    console.error("ERROR MSG");
+}

--- a/crates/pack-tests/tests/snapshot/optimization/remove_console/output/38c48_pack-tests_tests_snapshot_optimization_remove_console_input_index_4580a005.js
+++ b/crates/pack-tests/tests/snapshot/optimization/remove_console/output/38c48_pack-tests_tests_snapshot_optimization_remove_console_input_index_4580a005.js
@@ -1,0 +1,16 @@
+(globalThis.TURBOPACK || (globalThis.TURBOPACK = [])).push([typeof document === "object" ? document.currentScript : undefined,
+15, ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([
+    "main",
+    ()=>main
+]);
+function main() {
+    ;
+    console.error("ERROR MSG");
+}
+}),
+]);
+
+//# sourceMappingURL=38c48_pack-tests_tests_snapshot_optimization_remove_console_input_index_4580a005.js.map

--- a/crates/pack-tests/tests/snapshot/optimization/remove_console/output/38c48_pack-tests_tests_snapshot_optimization_remove_console_input_index_4580a005.js.map
+++ b/crates/pack-tests/tests/snapshot/optimization/remove_console/output/38c48_pack-tests_tests_snapshot_optimization_remove_console_input_index_4580a005.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/crates/pack-tests/tests/snapshot/optimization/remove_console/input/index.js"],"sourcesContent":["export function main() {\n    console.log(\"LOG MSG\");\n    console.error(\"ERROR MSG\");\n}"],"names":[],"mappings":";;;;AAAO,SAAS;;IAEZ,QAAQ,KAAK,CAAC;AAClB"}}]
+}

--- a/crates/pack-tests/tests/snapshot/optimization/remove_console/output/main.js
+++ b/crates/pack-tests/tests/snapshot/optimization/remove_console/output/main.js
@@ -1,0 +1,5 @@
+(globalThis.TURBOPACK || (globalThis.TURBOPACK = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["38c48_pack-tests_tests_snapshot_optimization_remove_console_input_index_4580a005.js"],"runtimeModuleIds":[15]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/optimization/remove_console/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/optimization/remove_console/output/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -580,6 +580,13 @@
           "default": false,
           "type": "boolean"
         },
+        "style": {
+          "description": "Style import configuration",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "transform": {
           "description": "Transform configuration",
           "allOf": [

--- a/packages/pack/src/types.ts
+++ b/packages/pack/src/types.ts
@@ -154,6 +154,9 @@ export interface ConfigComplete {
         transform: string | Record<string, string>;
         preventFullImport?: boolean;
         skipDefaultConversion?: boolean;
+        handleDefaultImport?: boolean;
+        handleNamespaceImport?: boolean;
+        style?: string;
       }
     >;
     packageImports?: string[];


### PR DESCRIPTION
## Summary

closes: #2165 

支持完整的 `babel-plugin-import` 能力支持，作用如下(也可以直接参考快照测试):

配置:

```json
"optimization": {
      "modularizeImports": {
        "antd": {
          "transform": "antd/es/{{ kebabCase member }}",
          "preventFullImport": false,
          "skipDefaultConversion": false,
          "style": "style"
        }
      },
}
```

用户代码:

```js
import { Button, DatePicker } from "antd";

console.log(Button);
console.log(DatePicker);
```

会被 transform 成:

```js
import Button from "antd/es/button";
import "antd/es/button/style";
import DatePicker from "antd/es/date-picker";
import "antd/es/date-picker/style";

console.log(Button);
console.log(DatePicker);
```

具体变现参考快照测试里面的 moduleIds：

<img width="2130" height="606" alt="image" src="https://github.com/user-attachments/assets/1588a744-a165-4a02-9e75-c09c3f867e1e" />

顺便添加一组 removeConsole 的 snapshot 测试，参考 twitter: https://x.com/vikingmute/status/1962800509569614158


## Test Plan

快照测试表现比较清晰。
