### PR TITLE
fix(pack): hmr not work for react app

### DIFF
--- a/crates/pack-core/js/src/react-refresh/internal/helpers.ts
+++ b/crates/pack-core/js/src/react-refresh/internal/helpers.ts
@@ -41,13 +41,17 @@ type ModuleHotStatus =
 
 type ModuleHotStatusHandler = (status: ModuleHotStatus) => void;
 
-declare const module: {
+type TurbopackModule = {
   hot: {
     status: () => ModuleHotStatus;
     addStatusHandler: (handler: ModuleHotStatusHandler) => void;
     removeStatusHandler: (handler: ModuleHotStatusHandler) => void;
   };
 };
+
+declare const __turbopack_context__: any;
+
+const { m: turbopackModule }: { m: TurbopackModule } = __turbopack_context__;
 
 function isSafeExport(key: string): boolean {
   return (
@@ -175,7 +179,7 @@ function scheduleUpdate() {
     }
   }
 
-  if (canApplyUpdate(module.hot.status())) {
+  if (canApplyUpdate(turbopackModule.hot.status())) {
     // Apply update on the next tick.
     Promise.resolve().then(() => {
       applyUpdate();
@@ -185,13 +189,13 @@ function scheduleUpdate() {
 
   const statusHandler = (status) => {
     if (canApplyUpdate(status)) {
-      module.hot.removeStatusHandler(statusHandler);
+      turbopackModule.hot.removeStatusHandler(statusHandler);
       applyUpdate();
     }
   };
 
   // Apply update once the HMR runtime's status is idle.
-  module.hot.addStatusHandler(statusHandler);
+  turbopackModule.hot.addStatusHandler(statusHandler);
 }
 
 // Needs to be compatible with IE11

--- a/crates/pack-core/src/client/react_refresh.rs
+++ b/crates/pack-core/src/client/react_refresh.rs
@@ -13,7 +13,7 @@ use turbopack_resolve::{
 
 #[turbo_tasks::function]
 fn react_refresh_request() -> Vc<Request> {
-    Request::parse_string("@utoo/pack-runtime/src/react-refresh/runtime".into())
+    Request::parse_string("@utoo/pack-runtime/react-refresh/runtime".into())
 }
 
 #[turbo_tasks::value]
@@ -103,7 +103,7 @@ impl Issue for ReactRefreshResolvingIssue {
                 )),
                 StyledString::Code(rcstr!("react-refresh")),
                 StyledString::Text(rcstr!(" and ")),
-                StyledString::Code(rcstr!("@utoo/pack-runtime/src/react-refresh/runtime")),
+                StyledString::Code(rcstr!("@utoo/pack-runtime/react-refresh/runtime")),
                 StyledString::Text(rcstr!(" modules.")),
             ])
             .resolved_cell(),

--- a/crates/pack-core/src/embed_js.rs
+++ b/crates/pack-core/src/embed_js.rs
@@ -4,7 +4,7 @@ use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileContent, FileSystem, FileSystemPath, embed_directory};
 
 #[turbo_tasks::function]
-fn embed_fs() -> Vc<Box<dyn FileSystem>> {
+pub fn embed_fs() -> Vc<Box<dyn FileSystem>> {
     embed_directory!("@utoo/pack-runtime", "$CARGO_MANIFEST_DIR/js/src")
 }
 

--- a/crates/pack-core/src/import_map.rs
+++ b/crates/pack-core/src/import_map.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
 };
 use turbopack_node::execution_context::ExecutionContext;
 
-use crate::{config::Config, mode::Mode, util::convert_to_project_relative};
+use crate::{config::Config, embed_js, mode::Mode, util::convert_to_project_relative};
 
 pub fn mdx_import_source_file() -> RcStr {
     unreachable!()
@@ -94,18 +94,28 @@ async fn insert_shared_aliases(
     {
         let pack_package = get_utoopack_path(project_path.clone()).owned().await?;
         import_map.insert_singleton_alias("@swc/helpers", pack_package.clone());
+        import_map.insert_singleton_alias("react-refresh", pack_package);
     }
     // import_map.insert_singleton_alias("styled-jsx", pack_package.clone());
     import_map.insert_singleton_alias("react", project_path.clone());
     import_map.insert_singleton_alias("react-dom", project_path.clone());
+
     insert_package_alias(
         import_map,
-        "@vercel/turbopack-ecmascript-runtime/",
+        rcstr!("@vercel/turbopack-ecmascript-runtime/"),
         turbopack_ecmascript_runtime::embed_fs()
             .root()
             .owned()
             .await?,
-    );
+    )
+    .await?;
+
+    insert_package_alias(
+        import_map,
+        rcstr!("@utoo/pack-runtime/"),
+        embed_js::embed_fs().root().owned().await?,
+    )
+    .await?;
 
     Ok(())
 }
@@ -208,13 +218,18 @@ fn insert_alias_to_alternatives<'a>(
     );
 }
 
-/// Inserts an alias to an import mapping into an import map.
 #[allow(dead_code)]
-fn insert_package_alias(import_map: &mut ImportMap, prefix: &str, package_root: FileSystemPath) {
+/// Inserts an alias to an import mapping into an import map.
+async fn insert_package_alias(
+    import_map: &mut ImportMap,
+    prefix: RcStr,
+    package_root: FileSystemPath,
+) -> Result<()> {
     import_map.insert_wildcard_alias(
         prefix,
-        ImportMapping::PrimaryAlternative("./*".into(), Some(package_root)).resolved_cell(),
+        ImportMapping::PrimaryAlternative(rcstr!("./*"), Some(package_root)).resolved_cell(),
     );
+    Ok(())
 }
 
 #[turbo_tasks::function]

--- a/crates/pack-core/src/import_map.rs
+++ b/crates/pack-core/src/import_map.rs
@@ -107,15 +107,13 @@ async fn insert_shared_aliases(
             .root()
             .owned()
             .await?,
-    )
-    .await?;
+    );
 
     insert_package_alias(
         import_map,
         rcstr!("@utoo/pack-runtime/"),
         embed_js::embed_fs().root().owned().await?,
-    )
-    .await?;
+    );
 
     Ok(())
 }
@@ -220,16 +218,11 @@ fn insert_alias_to_alternatives<'a>(
 
 #[allow(dead_code)]
 /// Inserts an alias to an import mapping into an import map.
-async fn insert_package_alias(
-    import_map: &mut ImportMap,
-    prefix: RcStr,
-    package_root: FileSystemPath,
-) -> Result<()> {
+fn insert_package_alias(import_map: &mut ImportMap, prefix: RcStr, package_root: FileSystemPath) {
     import_map.insert_wildcard_alias(
         prefix,
         ImportMapping::PrimaryAlternative(rcstr!("./*"), Some(package_root)).resolved_cell(),
     );
-    Ok(())
 }
 
 #[turbo_tasks::function]


### PR DESCRIPTION
## Summary

closes: #2204 


https://github.com/user-attachments/assets/dff2c929-4dc1-4ed4-bca4-b75b12bf74e4


主要是两个问题修复:

- 修复 react-refresh 的 runtime code 没有正确注入，导致 hmr 走不到 react-refresh 上的 runtime 逻辑来
- 修复 react-refresh runtime code 中找不到 `module` 导致 jsx 更新降级


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
