### PR TITLE
chore: disable rust-cache for pack CI/CD

### DIFF
--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -92,8 +92,8 @@ jobs:
         with:
           toolchain: nightly-2025-06-04
           targets: ${{ matrix.settings.target }}
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+      # - name: Cache cargo
+      #   uses: Swatinem/rust-cache@v2
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}
         if: ${{ matrix.settings.setup }}

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -93,8 +93,8 @@ jobs:
         with:
           toolchain: nightly-2025-06-04
           targets: ${{ matrix.settings.target }}
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+      # - name: Cache cargo
+      #   uses: Swatinem/rust-cache@v2
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}
         if: ${{ matrix.settings.setup }}


### PR DESCRIPTION
It's always timeout.