### PR TITLE
fix(pm): improve ut list error messages

### DIFF
--- a/crates/pm/src/cmd/list.rs
+++ b/crates/pm/src/cmd/list.rs
@@ -13,7 +13,9 @@ pub async fn list_dependencies(cwd: &Path, package_name: &str) -> Result<()> {
     let lock_file_path = cwd.join("package-lock.json");
     if !crate::fs::try_exists(&lock_file_path).await? {
         return Err(anyhow::anyhow!(
-            "package-lock.json not found in current directory"
+            "package-lock.json not found in the current directory. \
+             `utoo list` reads the dependency graph from the lockfile.\n\
+             Run `utoo install` to generate one, then re-run `utoo list`."
         ));
     }
 
@@ -89,9 +91,35 @@ mod tests {
     }
 
     #[test]
-    fn test_show_package_dependencies_not_found() {
+    fn test_show_package_dependencies_not_found_includes_package_name() {
         let graph = mock_graph();
         let result = show_package_dependencies(&graph, "not-exist");
         assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not-exist"),
+            "error should mention the queried package name, got: {err}"
+        );
+        assert!(
+            err.contains("utoo deps"),
+            "error should suggest `utoo deps`, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_dependencies_lockfile_missing_error() {
+        // A temp dir with no package-lock.json should produce a helpful error.
+        let dir = tempfile::tempdir().unwrap();
+        let result = list_dependencies(dir.path(), "some-package").await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("package-lock.json"),
+            "error should mention package-lock.json, got: {err}"
+        );
+        assert!(
+            err.contains("utoo install"),
+            "error should suggest `utoo install`, got: {err}"
+        );
     }
 }

--- a/crates/pm/src/service/dependency_graph.rs
+++ b/crates/pm/src/service/dependency_graph.rs
@@ -254,7 +254,10 @@ impl LockGraphService {
         let package_indices = self.find_package_indices_by_name(package_name);
 
         if package_indices.is_empty() {
-            return Err(anyhow::anyhow!("Package '{package_name}' not found"));
+            return Err(anyhow::anyhow!(
+                "Package '{package_name}' was not found in the lockfile.\n\
+                 Run `utoo deps` to list installed packages, or `utoo install` to sync the lockfile."
+            ));
         }
 
         let mut all_paths = Vec::new();
@@ -536,5 +539,33 @@ mod tests {
         let tree = build_dep_tree(&paths);
         // root should have one child (a)
         assert_eq!(tree.children.len(), 1);
+    }
+
+    #[test]
+    fn test_find_paths_to_root_not_found_includes_package_name() {
+        let graph = LockGraphService::new();
+        let result = graph.find_paths_to_root("nonexistent-package");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("nonexistent-package"),
+            "error should mention the queried package name, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_find_paths_to_root_not_found_suggests_actions() {
+        let graph = LockGraphService::new();
+        let result = graph.find_paths_to_root("nonexistent-package");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("utoo deps"),
+            "error should suggest `utoo deps`, got: {err}"
+        );
+        assert!(
+            err.contains("utoo install"),
+            "error should suggest `utoo install`, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
Improve error messages for `utoo list` / `utoo ls` when:

1. Lockfile (package-lock.json) is missing — the error now explains what is missing and suggests running `utoo install` to generate it.
2. Package is not found — the error now includes the queried package name and suggests `utoo deps` to list installed packages or `utoo install` to sync the lockfile.

Add tests covering both error paths.

Closes #3168

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/utooland/utoo/blob/next/README.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
