### PR TITLE
fix(pack): validate webpack config entry to prevent cryptic crash

### DIFF
--- a/packages/pack/src/config/webpackCompat.ts
+++ b/packages/pack/src/config/webpackCompat.ts
@@ -21,7 +21,15 @@ export function resolveBundleOptions(
     const loadedConfig = readWebpackConfig(projectPath, rootPath);
     webpackConfig = { ...loadedConfig, ...webpackConfig };
     try {
-      return compatOptionsFromWebpack(webpackConfig);
+      const result = compatOptionsFromWebpack(webpackConfig);
+      if (!result.config.entry || result.config.entry.length === 0) {
+        throw new Error(
+          'webpack.config.js is missing "entry" configuration.\n' +
+            'Please define an entry, for example:\n' +
+            '  module.exports = { entry: "./src/index.js" };',
+        );
+      }
+      return result;
     } catch (e) {
       throw new Error("Error converting webpack config: " + e);
     }

--- a/packages/pack/src/config/webpackCompat.ts
+++ b/packages/pack/src/config/webpackCompat.ts
@@ -25,7 +25,7 @@ export function resolveBundleOptions(
       if (!result.config.entry || result.config.entry.length === 0) {
         throw new Error(
           'webpack.config.js is missing "entry" configuration.\n' +
-            'Please define an entry, for example:\n' +
+            "Please define an entry, for example:\n" +
             '  module.exports = { entry: "./src/index.js" };',
         );
       }


### PR DESCRIPTION
When `webpack.config.js` exports an empty object, `entry` is `undefined` and `createHotReloader` crashes with "Cannot read properties of undefined (reading 'filter')". Add an early validation in `resolveBundleOptions` to throw a clear, actionable error instead.

```js
// webpack.config.js
module.exports = {};
```

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/utooland/utoo/blob/next/README.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<img width="1350" height="726" alt="image" src="https://github.com/user-attachments/assets/cadc4247-43f0-42d5-b974-9f7026c6cd26" />

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
