### PR TITLE
feat(pm): add config delete and rm alias commands (#3164)

### DIFF
--- a/crates/pm/schema/cli-output-v1.schema.json
+++ b/crates/pm/schema/cli-output-v1.schema.json
@@ -66,6 +66,9 @@
       "$ref": "#/definitions/ConfigListSuccessSchema"
     },
     {
+      "$ref": "#/definitions/ConfigDeleteSuccessSchema"
+    },
+    {
       "$ref": "#/definitions/InitSuccessSchema"
     },
     {
@@ -245,6 +248,64 @@
       "enum": [
         "config"
       ]
+    },
+    "ConfigDeleteResult": {
+      "type": "object",
+      "required": [
+        "deleted",
+        "key",
+        "scope"
+      ],
+      "properties": {
+        "deleted": {
+          "type": "boolean"
+        },
+        "key": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string"
+        }
+      }
+    },
+    "ConfigDeleteSubcommand": {
+      "type": "string",
+      "enum": [
+        "delete"
+      ]
+    },
+    "ConfigDeleteSuccessSchema": {
+      "type": "object",
+      "required": [
+        "command",
+        "durationMs",
+        "ok",
+        "result",
+        "schemaVersion",
+        "subcommand"
+      ],
+      "properties": {
+        "command": {
+          "$ref": "#/definitions/ConfigCommand"
+        },
+        "durationMs": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "ok": {
+          "$ref": "#/definitions/SuccessMarker"
+        },
+        "result": {
+          "$ref": "#/definitions/ConfigDeleteResult"
+        },
+        "schemaVersion": {
+          "$ref": "#/definitions/SchemaVersionOne"
+        },
+        "subcommand": {
+          "$ref": "#/definitions/ConfigDeleteSubcommand"
+        }
+      }
     },
     "ConfigGetResult": {
       "type": "object",

--- a/crates/pm/src/cli.rs
+++ b/crates/pm/src/cli.rs
@@ -125,6 +125,12 @@ pub enum ConfigCommands {
         #[arg(long)]
         global: bool,
     },
+    #[command(about = "Delete a configuration value by its key", alias = "rm")]
+    Delete {
+        key: String,
+        #[arg(long)]
+        global: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -343,6 +349,7 @@ impl ConfigCommands {
             Self::Set { .. } => "set",
             Self::Get { .. } => "get",
             Self::List { .. } => "list",
+            Self::Delete { .. } => "delete",
         }
     }
 }
@@ -562,5 +569,74 @@ mod tests {
             Some("uninstall"),
             "rm alias should map to uninstall subcommand"
         );
+    }
+
+    #[test]
+    fn test_config_delete_command_recognized() {
+        // Verify clap recognizes "config delete" as a valid subcommand
+        let cli = Cli::try_parse_from(["utoo", "config", "delete", "some-key"])
+            .unwrap_or_else(|e| panic!("`utoo config delete some-key` should parse, got: {e}"));
+        match cli.command {
+            Some(Commands::Config { command }) => {
+                assert!(
+                    matches!(command, ConfigCommands::Delete { global: false, .. }),
+                    "config delete should resolve to Delete with global=false"
+                );
+            }
+            _ => panic!("expected Config subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_config_delete_rm_alias_recognized() {
+        // Verify clap recognizes "rm" as an alias for config delete
+        let cmd = Cli::command();
+
+        // Test "rm" is recognized as a config delete command
+        let result = cmd
+            .clone()
+            .try_get_matches_from(["utoo", "config", "rm", "some-key"]);
+        assert!(
+            result.is_ok(),
+            "Should parse 'utoo config rm' as valid config delete command"
+        );
+
+        let matches = result.unwrap();
+        assert_eq!(
+            matches.subcommand_name(),
+            Some("config"),
+            "config subcommand should be recognized"
+        );
+
+        // The nested config subcommand should resolve to Delete
+        let cli = Cli::try_parse_from(["utoo", "config", "rm", "some-key"])
+            .unwrap_or_else(|e| panic!("`utoo config rm some-key` should parse, got: {e}"));
+        match cli.command {
+            Some(Commands::Config { command }) => {
+                assert!(
+                    matches!(command, ConfigCommands::Delete { .. }),
+                    "config rm alias should resolve to Delete"
+                );
+            }
+            _ => panic!("expected Config subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_config_delete_global_flag() {
+        // Verify the --global flag on config delete
+        let cli = Cli::try_parse_from(["utoo", "config", "delete", "--global", "some-key"])
+            .unwrap_or_else(|e| {
+                panic!("`utoo config delete --global some-key` should parse, got: {e}")
+            });
+        match cli.command {
+            Some(Commands::Config { command }) => {
+                assert!(
+                    matches!(command, ConfigCommands::Delete { global: true, .. }),
+                    "config delete --global should resolve to Delete with global=true"
+                );
+            }
+            _ => panic!("expected Config subcommand"),
+        }
     }
 }

--- a/crates/pm/src/cmd/config.rs
+++ b/crates/pm/src/cmd/config.rs
@@ -5,7 +5,9 @@ use serde_json::Value;
 
 use crate::cli::ConfigCommands;
 use crate::error::CliError;
-use crate::model::cli_output::{ConfigGetResult, ConfigListResult, ConfigSetResult};
+use crate::model::cli_output::{
+    ConfigDeleteResult, ConfigGetResult, ConfigListResult, ConfigSetResult,
+};
 use crate::util::cli_enum::ConfigScope;
 use crate::util::config_file::Config;
 use crate::util::presenter::emit;
@@ -22,6 +24,7 @@ pub async fn run(command: ConfigCommands) -> Result<()> {
             override_values,
         } => handle_config_get(key, global.into(), override_values).await,
         ConfigCommands::List { global } => handle_config_list(global.into()).await,
+        ConfigCommands::Delete { key, global } => handle_config_delete(key, global.into()).await,
     }
 }
 
@@ -47,6 +50,26 @@ pub async fn handle_config_set(key: String, value: String, scope: ConfigScope) -
     };
     emit("config", &output, || {
         println!("Successfully set {key} ({label})");
+        Ok(())
+    })
+}
+
+pub async fn handle_config_delete(key: String, scope: ConfigScope) -> Result<()> {
+    let mut config = Config::load(scope).await?;
+    let deleted = config.get(&key)?.is_some();
+    config.delete(&key, scope)?;
+    let label = if scope == ConfigScope::Global {
+        "global"
+    } else {
+        "local"
+    };
+    let output = ConfigDeleteResult {
+        key: key.clone(),
+        scope: label.to_string(),
+        deleted,
+    };
+    emit("config", &output, || {
+        println!("Successfully deleted {key} ({label})");
         Ok(())
     })
 }

--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -600,6 +600,7 @@ fn detect_subcommand(args: &[String]) -> Option<&'static str> {
             "set" => Some("set"),
             "get" => Some("get"),
             "list" => Some("list"),
+            "delete" | "rm" => Some("delete"),
             _ => None,
         };
     }

--- a/crates/pm/src/model/cli_output.rs
+++ b/crates/pm/src/model/cli_output.rs
@@ -509,6 +509,13 @@ pub struct ConfigSetResult {
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
+pub struct ConfigDeleteResult {
+    pub key: String,
+    pub scope: String,
+    pub deleted: bool,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct ConfigGetResult {
     pub values: BTreeMap<String, Value>,
     pub source: String,
@@ -706,6 +713,12 @@ config_success_schema!(
     "list",
     ConfigListResult
 );
+config_success_schema!(
+    ConfigDeleteSuccessSchema,
+    ConfigDeleteSubcommand,
+    "delete",
+    ConfigDeleteResult
+);
 
 #[derive(JsonSchema)]
 #[serde(untagged)]
@@ -732,6 +745,7 @@ enum CliOutputSchema {
     ConfigSet(ConfigSetSuccessSchema),
     ConfigGet(ConfigGetSuccessSchema),
     ConfigList(ConfigListSuccessSchema),
+    ConfigDelete(ConfigDeleteSuccessSchema),
     Init(InitSuccessSchema),
     Completions(CompletionsSuccessSchema),
     Custom(CustomSuccessSchema),

--- a/crates/pm/tests/cli_contract.rs
+++ b/crates/pm/tests/cli_contract.rs
@@ -700,6 +700,133 @@ fn config_json_uses_command_and_subcommand_fields() {
     assert_eq!(value["result"]["scope"], "local");
 }
 
+#[test]
+fn config_delete_local_roundtrip() {
+    let project = tempdir().unwrap();
+    let set = utoo()
+        .current_dir(project.path())
+        .args(["--json", "config", "set", "fixture-key", "fixture-value"])
+        .output()
+        .unwrap();
+    assert!(
+        set.status.success(),
+        "{}",
+        String::from_utf8_lossy(&set.stderr)
+    );
+
+    let output = utoo()
+        .current_dir(project.path())
+        .args(["--json", "config", "delete", "fixture-key"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["command"], "config");
+    assert_eq!(value["subcommand"], "delete");
+    assert_eq!(value["result"]["key"], "fixture-key");
+    assert_eq!(value["result"]["scope"], "local");
+    assert_eq!(value["result"]["deleted"], true);
+
+    let get = utoo()
+        .current_dir(project.path())
+        .args(["--json", "config", "get", "fixture-key"])
+        .output()
+        .unwrap();
+    assert_eq!(get.status.code(), Some(4));
+}
+
+#[test]
+fn config_delete_missing_key_is_idempotent_noop() {
+    let project = tempdir().unwrap();
+    let output = utoo()
+        .current_dir(project.path())
+        .args(["--json", "config", "delete", "never-set-key"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["command"], "config");
+    assert_eq!(value["subcommand"], "delete");
+    assert_eq!(value["result"]["deleted"], false);
+    assert_eq!(value["result"]["scope"], "local");
+}
+
+#[test]
+fn config_delete_rm_alias() {
+    let project = tempdir().unwrap();
+    let set = utoo()
+        .current_dir(project.path())
+        .args(["--json", "config", "set", "fixture-key", "fixture-value"])
+        .output()
+        .unwrap();
+    assert!(
+        set.status.success(),
+        "{}",
+        String::from_utf8_lossy(&set.stderr)
+    );
+
+    let output = utoo()
+        .current_dir(project.path())
+        .args(["--json", "config", "rm", "fixture-key"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["command"], "config");
+    assert_eq!(value["subcommand"], "delete");
+}
+
+#[test]
+fn config_delete_global_scope() {
+    let project = tempdir().unwrap();
+    let set = utoo()
+        .current_dir(project.path())
+        .env("HOME", project.path())
+        .env("USERPROFILE", project.path())
+        .args(["--json", "config", "set", "--global", "g-key", "g-val"])
+        .output()
+        .unwrap();
+    assert!(
+        set.status.success(),
+        "{}",
+        String::from_utf8_lossy(&set.stderr)
+    );
+
+    let output = utoo()
+        .current_dir(project.path())
+        .env("HOME", project.path())
+        .env("USERPROFILE", project.path())
+        .args(["--json", "config", "delete", "--global", "g-key"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["command"], "config");
+    assert_eq!(value["subcommand"], "delete");
+    assert_eq!(value["result"]["scope"], "global");
+    assert_eq!(value["result"]["deleted"], true);
+}
+
 #[cfg(unix)]
 #[test]
 fn execute_json_captures_child_output() {

--- a/docs/pm-cli-json.md
+++ b/docs/pm-cli-json.md
@@ -28,8 +28,8 @@ Failure:
 
 - `command` is the canonical first-level command; aliases are normalized. /
   `command` 是规范化的一级命令，别名会归一化。
-- `subcommand` is present for commands such as `config get`. /
-  `config get` 等命令使用 `subcommand`。
+- `subcommand` is present for commands such as `config get` and `config delete` (`rm`). /
+  `config get`、`config delete`（`rm`）等命令使用 `subcommand`。
 - `command` may be `null` only when argument parsing cannot identify it. /
   仅当参数解析无法识别命令时，`command` 才可能为 `null`。
 - `result` and `error` are mutually exclusive. / `result` 与 `error` 互斥。
@@ -46,7 +46,7 @@ Failure:
 | `execute`, `custom` | Captured process execution / 捕获的进程执行结果 |
 | `view`, `pack`, `publish` | Registry or package artifact metadata / Registry 与包产物元数据 |
 | `ping`, `whoami`, `logout` | Registry/authentication result / Registry 与认证结果 |
-| `config` | KV values plus `set`, `get`, or `list` / KV 值及对应子命令 |
+| `config` | KV values plus `set`, `get`, `delete` (`rm`), or `list` / KV 值及 `set`、`get`、`delete`（`rm`）、`list` 子命令 |
 | `init`, `completions`, `help`, `version` | Generated artifact or CLI metadata / 生成产物或 CLI 元数据 |
 
 `login --json` returns the usage error `interactive_required`; the browser login


### PR DESCRIPTION
## Summary

Closes #3164. Expose the existing `Config::delete` capability through the CLI:

- Add `utoo config delete <key>` subcommand
- Add `rm` alias: `utoo config rm <key>`
- Support `--global` flag, consistent with `set`/`get`/`list`
- Deleting a non-existing key is an idempotent no-op (JSON reports `deleted: false`)
- Add CLI parsing tests and command-level integration tests
- Regenerate CLI output JSON schema + update docs

## Test Plan

- `cargo test -p utoo-pm test_config_delete` — 3 CLI parsing tests
- `cargo test -p utoo-pm --test cli_contract config_delete` — 4 integration tests (roundtrip / idempotent no-op / rm alias / --global)
- `cargo test -p utoo-pm cli_output_schema` — schema snapshot in sync
- Manual QA: set → delete → re-delete (idempotent) → rm alias → `--json` output (`subcommand: "delete"`) → `get` after delete exits 4 → `--global` scope → `config --help` shows `delete`