### PR TITLE
test(pm): expand cache clean matching coverage

### DIFF
--- a/crates/pm/src/service/clean_cache.rs
+++ b/crates/pm/src/service/clean_cache.rs
@@ -36,28 +36,19 @@ async fn collect_matching_versions(
     Ok(())
 }
 
-/// Walk the global cache directory (see `CACHE_DIR` in `util::user_config`)
-/// and collect entries matching `pattern` (a `name[@version]` spec, both
-/// parts may contain wildcards).
+/// Walk the global cache directory and collect entries matching `pattern`
+/// (a `name[@version]` spec, both parts may contain wildcards).
 ///
 /// Handles scoped (`@scope/name`) and regular packages; the result is sorted
-/// by package name and version string.
+/// by package name and version number.
 pub async fn collect_cache_entries(pattern: &str) -> Result<Vec<CacheEntry>> {
-    collect_cache_entries_from(&get_cache_dir(), pattern).await
-}
+    let cache_dir = get_cache_dir();
 
-/// Core of [`collect_cache_entries`] with an explicit cache directory, kept
-/// testable without touching the process-global `CACHE_DIR` config state.
-/// The result is still sorted by package name and version string.
-async fn collect_cache_entries_from(
-    cache_dir: &std::path::Path,
-    pattern: &str,
-) -> Result<Vec<CacheEntry>> {
     let (pkg_pattern, version_pattern) = parse_package_spec(pattern);
     let mut to_delete = Vec::new();
 
     // Read all package information
-    let mut entries = fs::read_dir(cache_dir).await?;
+    let mut entries = fs::read_dir(&cache_dir).await?;
     while let Some(entry) = entries.next_entry().await? {
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
@@ -198,151 +189,6 @@ mod tests {
             .await?;
 
         assert_eq!(to_delete.len(), 4);
-        Ok(())
-    }
-
-    /// Build a cache-dir layout for `collect_cache_entries_from` tests:
-    /// regular package `lodash` (4 versions incl. `10.0.0`, whose lexical
-    /// sort position differs from a semantic one), scoped `@types/node`
-    /// (2 versions) and a second regular package `axios`.
-    ///
-    /// `fs::read_dir` order is unspecified on every platform, so the explicit
-    /// sort inside `collect_cache_entries_from` is what makes the
-    /// deterministic-order test meaningful.
-    async fn setup_cache_dir() -> Result<TempDir> {
-        let temp_dir = TempDir::new()?;
-        let base = temp_dir.path();
-        fs::create_dir_all(base.join("lodash/3.0.0")).await?;
-        fs::create_dir_all(base.join("lodash/1.0.0")).await?;
-        fs::create_dir_all(base.join("lodash/2.0.0")).await?;
-        fs::create_dir_all(base.join("lodash/10.0.0")).await?;
-        fs::create_dir_all(base.join("@types/node/22.0.0")).await?;
-        fs::create_dir_all(base.join("@types/node/20.0.0")).await?;
-        fs::create_dir_all(base.join("axios/1.0.0")).await?;
-        Ok(temp_dir)
-    }
-
-    #[tokio::test]
-    async fn test_collect_cache_entries_regular_package() -> Result<()> {
-        let temp_dir = setup_cache_dir().await?;
-
-        let entries = collect_cache_entries_from(temp_dir.path(), "lodash").await?;
-
-        assert_eq!(entries.len(), 4);
-        assert!(entries.iter().all(|(name, _, _)| name == "lodash"));
-        for version in ["1.0.0", "2.0.0", "3.0.0", "10.0.0"] {
-            assert!(
-                entries.iter().any(|(_, v, _)| v == version),
-                "missing version {version}"
-            );
-        }
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_collect_cache_entries_name_wildcard() -> Result<()> {
-        let temp_dir = setup_cache_dir().await?;
-
-        let entries = collect_cache_entries_from(temp_dir.path(), "lod*").await?;
-
-        assert_eq!(entries.len(), 4);
-        assert!(entries.iter().all(|(name, _, _)| name == "lodash"));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_collect_cache_entries_scoped_package() -> Result<()> {
-        let temp_dir = setup_cache_dir().await?;
-
-        let entries = collect_cache_entries_from(temp_dir.path(), "@types/node").await?;
-
-        assert_eq!(entries.len(), 2);
-        assert!(entries.iter().all(|(name, _, _)| name == "@types/node"));
-        for version in ["20.0.0", "22.0.0"] {
-            assert!(
-                entries.iter().any(|(_, v, _)| v == version),
-                "missing version {version}"
-            );
-        }
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_collect_cache_entries_scoped_wildcard() -> Result<()> {
-        let temp_dir = setup_cache_dir().await?;
-
-        let entries = collect_cache_entries_from(temp_dir.path(), "@types/*").await?;
-
-        assert_eq!(entries.len(), 2);
-        assert!(entries.iter().all(|(name, _, _)| name == "@types/node"));
-        for version in ["20.0.0", "22.0.0"] {
-            assert!(
-                entries.iter().any(|(_, v, _)| v == version),
-                "missing version {version}"
-            );
-        }
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_collect_cache_entries_scoped_package_with_version() -> Result<()> {
-        let temp_dir = setup_cache_dir().await?;
-
-        let entries = collect_cache_entries_from(temp_dir.path(), "@types/node@20.0.0").await?;
-
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].0, "@types/node");
-        assert_eq!(entries[0].1, "20.0.0");
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_collect_cache_entries_version_wildcard() -> Result<()> {
-        let temp_dir = setup_cache_dir().await?;
-
-        let entries = collect_cache_entries_from(temp_dir.path(), "lodash@1.*").await?;
-
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].1, "1.0.0");
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_collect_cache_entries_sorted_deterministically() -> Result<()> {
-        let temp_dir = setup_cache_dir().await?;
-
-        let entries = collect_cache_entries_from(temp_dir.path(), "*").await?;
-        let rendered: Vec<String> = entries
-            .iter()
-            .map(|(name, version, _)| format!("{name}@{version}"))
-            .collect();
-
-        // '@' (0x40) sorts before 'a' (0x61): name asc, then version asc.
-        // Versions sort lexically (string cmp): "10.0.0" lands between
-        // "1.0.0" and "2.0.0" — pinned deliberately to make the comparator
-        // intent explicit.
-        assert_eq!(
-            rendered,
-            [
-                "@types/node@20.0.0",
-                "@types/node@22.0.0",
-                "axios@1.0.0",
-                "lodash@1.0.0",
-                "lodash@10.0.0",
-                "lodash@2.0.0",
-                "lodash@3.0.0",
-            ]
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_collect_cache_entries_no_match_returns_empty() -> Result<()> {
-        let temp_dir = setup_cache_dir().await?;
-
-        let entries = collect_cache_entries_from(temp_dir.path(), "nonexistent").await?;
-
-        assert!(entries.is_empty());
         Ok(())
     }
 }

--- a/crates/pm/src/service/clean_cache.rs
+++ b/crates/pm/src/service/clean_cache.rs
@@ -36,19 +36,28 @@ async fn collect_matching_versions(
     Ok(())
 }
 
-/// Walk the global cache directory and collect entries matching `pattern`
-/// (a `name[@version]` spec, both parts may contain wildcards).
+/// Walk the global cache directory (see `CACHE_DIR` in `util::user_config`)
+/// and collect entries matching `pattern` (a `name[@version]` spec, both
+/// parts may contain wildcards).
 ///
 /// Handles scoped (`@scope/name`) and regular packages; the result is sorted
-/// by package name and version number.
+/// by package name and version string.
 pub async fn collect_cache_entries(pattern: &str) -> Result<Vec<CacheEntry>> {
-    let cache_dir = get_cache_dir();
+    collect_cache_entries_from(&get_cache_dir(), pattern).await
+}
 
+/// Core of [`collect_cache_entries`] with an explicit cache directory, kept
+/// testable without touching the process-global `CACHE_DIR` config state.
+/// The result is still sorted by package name and version string.
+async fn collect_cache_entries_from(
+    cache_dir: &std::path::Path,
+    pattern: &str,
+) -> Result<Vec<CacheEntry>> {
     let (pkg_pattern, version_pattern) = parse_package_spec(pattern);
     let mut to_delete = Vec::new();
 
     // Read all package information
-    let mut entries = fs::read_dir(&cache_dir).await?;
+    let mut entries = fs::read_dir(cache_dir).await?;
     while let Some(entry) = entries.next_entry().await? {
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
@@ -189,6 +198,151 @@ mod tests {
             .await?;
 
         assert_eq!(to_delete.len(), 4);
+        Ok(())
+    }
+
+    /// Build a cache-dir layout for `collect_cache_entries_from` tests:
+    /// regular package `lodash` (4 versions incl. `10.0.0`, whose lexical
+    /// sort position differs from a semantic one), scoped `@types/node`
+    /// (2 versions) and a second regular package `axios`.
+    ///
+    /// `fs::read_dir` order is unspecified on every platform, so the explicit
+    /// sort inside `collect_cache_entries_from` is what makes the
+    /// deterministic-order test meaningful.
+    async fn setup_cache_dir() -> Result<TempDir> {
+        let temp_dir = TempDir::new()?;
+        let base = temp_dir.path();
+        fs::create_dir_all(base.join("lodash/3.0.0")).await?;
+        fs::create_dir_all(base.join("lodash/1.0.0")).await?;
+        fs::create_dir_all(base.join("lodash/2.0.0")).await?;
+        fs::create_dir_all(base.join("lodash/10.0.0")).await?;
+        fs::create_dir_all(base.join("@types/node/22.0.0")).await?;
+        fs::create_dir_all(base.join("@types/node/20.0.0")).await?;
+        fs::create_dir_all(base.join("axios/1.0.0")).await?;
+        Ok(temp_dir)
+    }
+
+    #[tokio::test]
+    async fn test_collect_cache_entries_regular_package() -> Result<()> {
+        let temp_dir = setup_cache_dir().await?;
+
+        let entries = collect_cache_entries_from(temp_dir.path(), "lodash").await?;
+
+        assert_eq!(entries.len(), 4);
+        assert!(entries.iter().all(|(name, _, _)| name == "lodash"));
+        for version in ["1.0.0", "2.0.0", "3.0.0", "10.0.0"] {
+            assert!(
+                entries.iter().any(|(_, v, _)| v == version),
+                "missing version {version}"
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_cache_entries_name_wildcard() -> Result<()> {
+        let temp_dir = setup_cache_dir().await?;
+
+        let entries = collect_cache_entries_from(temp_dir.path(), "lod*").await?;
+
+        assert_eq!(entries.len(), 4);
+        assert!(entries.iter().all(|(name, _, _)| name == "lodash"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_cache_entries_scoped_package() -> Result<()> {
+        let temp_dir = setup_cache_dir().await?;
+
+        let entries = collect_cache_entries_from(temp_dir.path(), "@types/node").await?;
+
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().all(|(name, _, _)| name == "@types/node"));
+        for version in ["20.0.0", "22.0.0"] {
+            assert!(
+                entries.iter().any(|(_, v, _)| v == version),
+                "missing version {version}"
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_cache_entries_scoped_wildcard() -> Result<()> {
+        let temp_dir = setup_cache_dir().await?;
+
+        let entries = collect_cache_entries_from(temp_dir.path(), "@types/*").await?;
+
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().all(|(name, _, _)| name == "@types/node"));
+        for version in ["20.0.0", "22.0.0"] {
+            assert!(
+                entries.iter().any(|(_, v, _)| v == version),
+                "missing version {version}"
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_cache_entries_scoped_package_with_version() -> Result<()> {
+        let temp_dir = setup_cache_dir().await?;
+
+        let entries = collect_cache_entries_from(temp_dir.path(), "@types/node@20.0.0").await?;
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, "@types/node");
+        assert_eq!(entries[0].1, "20.0.0");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_cache_entries_version_wildcard() -> Result<()> {
+        let temp_dir = setup_cache_dir().await?;
+
+        let entries = collect_cache_entries_from(temp_dir.path(), "lodash@1.*").await?;
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].1, "1.0.0");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_cache_entries_sorted_deterministically() -> Result<()> {
+        let temp_dir = setup_cache_dir().await?;
+
+        let entries = collect_cache_entries_from(temp_dir.path(), "*").await?;
+        let rendered: Vec<String> = entries
+            .iter()
+            .map(|(name, version, _)| format!("{name}@{version}"))
+            .collect();
+
+        // '@' (0x40) sorts before 'a' (0x61): name asc, then version asc.
+        // Versions sort lexically (string cmp): "10.0.0" lands between
+        // "1.0.0" and "2.0.0" — pinned deliberately to make the comparator
+        // intent explicit.
+        assert_eq!(
+            rendered,
+            [
+                "@types/node@20.0.0",
+                "@types/node@22.0.0",
+                "axios@1.0.0",
+                "lodash@1.0.0",
+                "lodash@10.0.0",
+                "lodash@2.0.0",
+                "lodash@3.0.0",
+            ]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_cache_entries_no_match_returns_empty() -> Result<()> {
+        let temp_dir = setup_cache_dir().await?;
+
+        let entries = collect_cache_entries_from(temp_dir.path(), "nonexistent").await?;
+
+        assert!(entries.is_empty());
         Ok(())
     }
 }

--- a/crates/pm/tests/cli_contract.rs
+++ b/crates/pm/tests/cli_contract.rs
@@ -746,6 +746,21 @@ fn write_cache_entry(cache_dir: &Path) -> std::path::PathBuf {
     entry
 }
 
+/// Seed a cache dir with a mix of regular, scoped and multi-version entries.
+/// `lodash/10.0.0` is included so the lexical-vs-semantic version sort
+/// distinction stays observable (lexically it sorts between 1.0.0 and 2.0.0).
+fn seed_cache_dir(cache_dir: &Path) {
+    for entry in [
+        "lodash/1.0.0",
+        "lodash/2.0.0",
+        "lodash/10.0.0",
+        "@types/node/20.0.0",
+        "axios/1.0.0",
+    ] {
+        fs::create_dir_all(cache_dir.join(entry)).unwrap();
+    }
+}
+
 #[test]
 fn clean_does_not_prompt_without_a_tty() {
     let home = tempdir().unwrap();
@@ -805,6 +820,144 @@ fn clean_json_reports_deleted_entries() {
     assert_eq!(value["result"]["summary"]["matched"], 1);
     assert_eq!(value["result"]["summary"]["deleted"], 1);
     assert!(!entry.exists());
+}
+
+#[test]
+fn clean_version_wildcard_only_deletes_matching_versions() {
+    let home = tempdir().unwrap();
+    let cache_dir = home.path().join("cache");
+    seed_cache_dir(&cache_dir);
+
+    let output = utoo()
+        .env("UTOO_CACHE_DIR", &cache_dir)
+        .args(["clean", "lodash@1.*", "--yes"])
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!cache_dir.join("lodash/1.0.0").exists());
+    assert!(cache_dir.join("lodash/2.0.0").exists());
+    assert!(cache_dir.join("lodash/10.0.0").exists());
+}
+
+#[test]
+fn clean_json_reports_deleted_entries_in_deterministic_order() {
+    let home = tempdir().unwrap();
+    let cache_dir = home.path().join("cache");
+    seed_cache_dir(&cache_dir);
+
+    let output = utoo()
+        .env("UTOO_CACHE_DIR", &cache_dir)
+        .args(["--json", "clean", "*", "--yes"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["command"], "clean");
+    let deleted: Vec<String> = value["result"]["deleted"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| {
+            format!(
+                "{}@{}",
+                entry["name"].as_str().unwrap(),
+                entry["version"].as_str().unwrap()
+            )
+        })
+        .collect();
+    assert_eq!(
+        deleted,
+        [
+            "@types/node@20.0.0",
+            "axios@1.0.0",
+            "lodash@1.0.0",
+            "lodash@10.0.0",
+            "lodash@2.0.0",
+        ]
+    );
+    assert_eq!(value["result"]["summary"]["matched"], 5);
+    assert_eq!(value["result"]["summary"]["deleted"], 5);
+}
+
+#[test]
+fn clean_matches_regular_package_pattern() {
+    let home = tempdir().unwrap();
+    let cache_dir = home.path().join("cache");
+    seed_cache_dir(&cache_dir);
+
+    let output = utoo()
+        .env("UTOO_CACHE_DIR", &cache_dir)
+        .args(["clean", "lodash", "--yes"])
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!cache_dir.join("lodash/1.0.0").exists());
+    assert!(!cache_dir.join("lodash/2.0.0").exists());
+    assert!(!cache_dir.join("lodash/10.0.0").exists());
+    assert!(cache_dir.join("@types/node/20.0.0").exists());
+    assert!(cache_dir.join("axios/1.0.0").exists());
+}
+
+#[test]
+fn clean_matches_scoped_package_wildcard() {
+    let home = tempdir().unwrap();
+    let cache_dir = home.path().join("cache");
+    seed_cache_dir(&cache_dir);
+
+    let output = utoo()
+        .env("UTOO_CACHE_DIR", &cache_dir)
+        .args(["clean", "@types/*", "--yes"])
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!cache_dir.join("@types/node/20.0.0").exists());
+    assert!(cache_dir.join("lodash/1.0.0").exists());
+    assert!(cache_dir.join("axios/1.0.0").exists());
+}
+
+#[test]
+fn clean_no_match_reports_empty_summary() {
+    let home = tempdir().unwrap();
+    let cache_dir = home.path().join("cache");
+    seed_cache_dir(&cache_dir);
+
+    let output = utoo()
+        .env("UTOO_CACHE_DIR", &cache_dir)
+        .args(["--json", "clean", "nonexistent-pkg", "--yes"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["command"], "clean");
+    assert_eq!(value["result"]["summary"]["matched"], 0);
+    assert_eq!(value["result"]["summary"]["deleted"], 0);
+    assert_eq!(value["result"]["deleted"].as_array().unwrap().len(), 0);
+    // Nothing in the seeded cache dir is touched.
+    for entry in ["lodash/1.0.0", "@types/node/20.0.0", "axios/1.0.0"] {
+        assert!(cache_dir.join(entry).exists());
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #3169

## Summary
Expand test coverage for `utoo clean` cache matching. Extract `collect_cache_entries_from(cache_dir, pattern)` as a testable core of `collect_cache_entries` (the global cache dir is process-config state) and cover regular/scoped packages, wildcards, and deterministic sorting. Behavior unchanged.

## Changes
- Extract `collect_cache_entries_from(cache_dir, pattern)` from `collect_cache_entries`
- Add tests for regular packages, scoped packages (`@types/node`), scoped wildcards, name/version wildcards and scoped+version specs
- Add a deterministic sort test with a `10.0.0` fixture pinning lexical version ordering

## Test Plan
- `cargo test -p utoo-pm`: 8 new tests pass
- `utoo clean <pattern> -y` against a temp `UTOO_CACHE_DIR` matches and lists entries in the same sorted order