### PR TITLE
fix(pack): preserve cyclic reexports

### DIFF
--- a/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_barrel/output/input_c08dd8d9.js
+++ b/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_barrel/output/input_c08dd8d9.js
@@ -74,9 +74,9 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexp
 
 __turbopack_context__.s([
     "Base",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_barrel$2f$input$2f$shape$2f$base$2e$js__$5b$client$5d$__$28$ecmascript$29$__["default"],
+    ()=>(__TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_barrel$2f$input$2f$shape$2f$base$2e$js__$5b$client$5d$__$28$ecmascript$29$__ ?? __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_barrel/input/shape/base.js [client] (ecmascript)"))["default"],
     "Path",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_barrel$2f$input$2f$shape$2f$path$2e$js__$5b$client$5d$__$28$ecmascript$29$__["default"]
+    ()=>(__TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_barrel$2f$input$2f$shape$2f$path$2e$js__$5b$client$5d$__$28$ecmascript$29$__ ?? __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_barrel/input/shape/path.js [client] (ecmascript)"))["default"]
 ]);
 var __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_barrel$2f$input$2f$shape$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__$3c$locals$3e$__ = __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_barrel/input/shape/index.js [client] (ecmascript) <locals>");
 var __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_barrel$2f$input$2f$shape$2f$base$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_barrel/input/shape/base.js [client] (ecmascript)");

--- a/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/config.json
+++ b/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.js",
+        "name": "main"
+      }
+    ],
+    "optimization": {
+      "minify": false,
+      "moduleIds": "named"
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/input/barrel.js
+++ b/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/input/barrel.js
@@ -1,0 +1,2 @@
+export * from './base.js';
+export * from './child.js';

--- a/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/input/base.js
+++ b/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/input/base.js
@@ -1,0 +1,1 @@
+export class Base {}

--- a/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/input/child.js
+++ b/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/input/child.js
@@ -1,0 +1,3 @@
+import { Base } from './barrel.js';
+
+export class Child extends Base {}

--- a/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/input/index.js
+++ b/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/input/index.js
@@ -1,0 +1,3 @@
+import { Child } from './barrel.js';
+
+console.log(new Child() instanceof Child);

--- a/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/output/input_cb27af7a.js
+++ b/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/output/input_cb27af7a.js
@@ -1,0 +1,57 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/circular_dependency/reexport_cycle_class/input/base.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+class Base {
+}
+__turbopack_context__.s([
+    "Base",
+    0,
+    Base
+]);
+}),
+"[project]/circular_dependency/reexport_cycle_class/input/child.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([
+    "Child",
+    ()=>Child
+]);
+var __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_class$2f$input$2f$barrel$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_class/input/barrel.js [client] (ecmascript)");
+;
+class Child extends __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_class$2f$input$2f$barrel$2e$js__$5b$client$5d$__$28$ecmascript$29$__["Base"] {
+}
+}),
+"[project]/circular_dependency/reexport_cycle_class/input/barrel.js [client] (ecmascript) <locals>", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([]);
+var __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_class$2f$input$2f$base$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_class/input/base.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_class$2f$input$2f$child$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_class/input/child.js [client] (ecmascript)");
+;
+;
+}),
+"[project]/circular_dependency/reexport_cycle_class/input/barrel.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([
+    "Base",
+    ()=>(__TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_class$2f$input$2f$base$2e$js__$5b$client$5d$__$28$ecmascript$29$__ ?? __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_class/input/base.js [client] (ecmascript)"))["Base"],
+    "Child",
+    ()=>(__TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_class$2f$input$2f$child$2e$js__$5b$client$5d$__$28$ecmascript$29$__ ?? __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_class/input/child.js [client] (ecmascript)"))["Child"]
+]);
+var __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_class$2f$input$2f$barrel$2e$js__$5b$client$5d$__$28$ecmascript$29$__$3c$locals$3e$__ = __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_class/input/barrel.js [client] (ecmascript) <locals>");
+var __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_class$2f$input$2f$base$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_class/input/base.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_class$2f$input$2f$child$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_class/input/child.js [client] (ecmascript)");
+}),
+"[project]/circular_dependency/reexport_cycle_class/input/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_class$2f$input$2f$barrel$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/circular_dependency/reexport_cycle_class/input/barrel.js [client] (ecmascript)");
+;
+console.log(new __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_class$2f$input$2f$barrel$2e$js__$5b$client$5d$__$28$ecmascript$29$__["Child"]() instanceof __TURBOPACK__imported__module__$5b$project$5d2f$circular_dependency$2f$reexport_cycle_class$2f$input$2f$barrel$2e$js__$5b$client$5d$__$28$ecmascript$29$__["Child"]);
+__turbopack_context__.s([]);
+}),
+]);
+
+//# sourceMappingURL=input_cb27af7a.js.map

--- a/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/output/input_cb27af7a.js.map
+++ b/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/output/input_cb27af7a.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/circular_dependency/reexport_cycle_class/input/base.js"],"sourcesContent":["export class Base {}\n"],"names":["Base"],"mappings":"AAAO,MAAMA;AAAM"}},
+    {"offset": {"line": 15, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/circular_dependency/reexport_cycle_class/input/child.js"],"sourcesContent":["import { Base } from './barrel.js';\n\nexport class Child extends Base {}\n"],"names":["Child"],"mappings":";;;;AAAA;;AAEO,MAAMA,cAAc,kKAAI;AAAE"}},
+    {"offset": {"line": 27, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/circular_dependency/reexport_cycle_class/input/barrel.js"],"sourcesContent":["export * from './base.js';\nexport * from './child.js';\n"],"names":[],"mappings":";AAAA;AACA"}},
+    {"offset": {"line": 49, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/circular_dependency/reexport_cycle_class/input/index.js"],"sourcesContent":["import { Child } from './barrel.js';\n\nconsole.log(new Child() instanceof Child);\n"],"names":["console","log"],"mappings":"AAAA;;AAEAA,QAAQC,GAAG,CAAC,IAAI,mKAAK,cAAc,mKAAK"}}]
+}

--- a/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/output/main.js
+++ b/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/output/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["input_cb27af7a.js"],"runtimeModuleIds":["[project]/circular_dependency/reexport_cycle_class/input/index.js [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/circular_dependency/reexport_cycle_class/output/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}


### PR DESCRIPTION
## What

- update the `next.js` submodule to include utooland/next.js#178
- add a minimal Pack snapshot for a class imported through the same barrel that re-exports it
- refresh the existing complex circular re-export snapshot for the lazy namespace fallback

## Why

A cyclic barrel can expose a re-export getter before its generated namespace binding has been initialized. The linked Turbopack fix keeps normal reads unchanged, but lets circuit-breaker getters fall back to the module namespace that already exists in the runtime cache.

## Related

- umijs/umi#13410

## Dependency

- Depends on utooland/next.js#178

## Checks

- `cargo test -p pack-tests --test snapshot reexport_cycle -- --nocapture`
- `cargo clippy -p pack-tests --all-targets -- -D warnings --no-deps`
- `cargo fmt --all -- --check`
- pre-push formatting and Biome checks
- `git diff --check`