### PR TITLE
chore(pack): update lightningcss to v1.33.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4048,8 +4048,8 @@ checksum = "0c6639b70a7ce854b79c70d7e83f16b5dc0137cc914f3d7d03803b513ecc67ac"
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.71"
-source = "git+https://github.com/utooland/lightningcss?branch=support-css-module-global#528670c67e3c93a6760acee265c929a3a1102e3c"
+version = "1.0.0-alpha.72"
+source = "git+https://github.com/utooland/lightningcss?branch=support-css-module-global#9ad2ff8f751223ba7cd95a5ee847a200bdfee487"
 dependencies = [
  "ahash 0.8.12",
  "bitflags 2.9.4",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "lightningcss-derive"
 version = "1.0.0-alpha.43"
-source = "git+https://github.com/utooland/lightningcss?branch=support-css-module-global#528670c67e3c93a6760acee265c929a3a1102e3c"
+source = "git+https://github.com/utooland/lightningcss?branch=support-css-module-global#9ad2ff8f751223ba7cd95a5ee847a200bdfee487"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -5304,8 +5304,8 @@ dependencies = [
 
 [[package]]
 name = "parcel_selectors"
-version = "0.28.2"
-source = "git+https://github.com/utooland/lightningcss?branch=support-css-module-global#528670c67e3c93a6760acee265c929a3a1102e3c"
+version = "0.28.3"
+source = "git+https://github.com/utooland/lightningcss?branch=support-css-module-global#9ad2ff8f751223ba7cd95a5ee847a200bdfee487"
 dependencies = [
  "bitflags 2.9.4",
  "cssparser",
@@ -7378,7 +7378,7 @@ dependencies = [
 [[package]]
 name = "static-self"
 version = "0.1.2"
-source = "git+https://github.com/utooland/lightningcss?branch=support-css-module-global#528670c67e3c93a6760acee265c929a3a1102e3c"
+source = "git+https://github.com/utooland/lightningcss?branch=support-css-module-global#9ad2ff8f751223ba7cd95a5ee847a200bdfee487"
 dependencies = [
  "indexmap 2.13.0",
  "smallvec",
@@ -7388,7 +7388,7 @@ dependencies = [
 [[package]]
 name = "static-self-derive"
 version = "0.1.1"
-source = "git+https://github.com/utooland/lightningcss?branch=support-css-module-global#528670c67e3c93a6760acee265c929a3a1102e3c"
+source = "git+https://github.com/utooland/lightningcss?branch=support-css-module-global#9ad2ff8f751223ba7cd95a5ee847a200bdfee487"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ sha1                              = "0.10"
 sha2                              = "0.10"
 url                               = "2.2.2"
 urlencoding                       = "2.1.2"
-lightningcss                      = { version = "1.0.0-alpha.71", features = [
+lightningcss                      = { version = "1.0.0-alpha.72", features = [
   "browserslist",
   "into_owned",
   "serde",


### PR DESCRIPTION
## What changed

- update the workspace `lightningcss` requirement from `1.0.0-alpha.71` to `1.0.0-alpha.72`
- lock the Lightning CSS fork packages to `utooland/lightningcss@ed3e9e0`
- update the `next.js` submodule to `utooland/next.js@64974d4d387`

Dependency PR: utooland/next.js#179

## Why

The Utoo Lightning CSS fork has been synchronized with upstream v1.33.0 while retaining the five Utoo-specific patches for CSS Modules, import parsing, custom properties, and backdrop-filter behavior.

## Validation

- Lightning CSS fork: 120 library tests passed
- `cargo +nightly-2026-07-29 check --locked -p turbopack-css` in the `next.js` submodule
- `cargo +nightly-2026-07-29 check --locked -p pack-core`
- `cargo +nightly-2026-07-29 test --locked -p pack-tests` (124 passed, 20 ignored)
- pre-push formatting, Biome, and spelling checks passed