### PR TITLE
feat(pm): support packageManager self-pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ uses the same package-manager implementation:
 
 When a local dependency command runs with another Utoo version, Utoo downloads
 the matching native release, verifies the registry checksum, caches it under
-`~/.cache/nm/self/<version>@<platform>`, and hands the command off with the same
+`~/.cache/nm/self-<platform>/<version>`, and hands the command off with the same
 arguments, working directory, and exit behavior. Warm caches work offline. An
 invalid cached release is never executed and is reprovisioned from the registry
 when available. This applies to local install/add, uninstall, update, rebuild,

--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ ut add lodash       # Add a package (or use `ut add`)
 ut x create-react   # Execute a package (npx style, or use `ut x`)
 ```
 
+Pin the project to an exact Utoo release so every contributor and CI runner
+uses the same package-manager implementation:
+
+```json
+{
+  "packageManager": "utoo@1.1.8"
+}
+```
+
+When a local dependency command runs with another Utoo version, Utoo downloads
+the matching native release, verifies the registry checksum, caches it under
+`~/.cache/nm/self/<version>`, and hands the command off with the same arguments,
+working directory, and exit behavior. Warm caches work offline. This applies to
+local install/add, uninstall, update, rebuild, and deps commands; scripts,
+`ut x`, query commands, and global installs keep using the current executable.
+Set `UTOO_SELF_PIN=0` to bypass the handoff temporarily.
+
 #### Bundling via @utoo/pack-cli
 ```bash
 utx up dev          # Start dev server with HMR
@@ -98,4 +115,3 @@ We love contributions! Check out [CONTRIBUTING.md](CONTRIBUTING.md) to get start
 ## 📄 License
 
 Utoo is licensed under the [MIT License](LICENSE).
-

--- a/README.md
+++ b/README.md
@@ -80,11 +80,13 @@ uses the same package-manager implementation:
 
 When a local dependency command runs with another Utoo version, Utoo downloads
 the matching native release, verifies the registry checksum, caches it under
-`~/.cache/nm/self/<version>`, and hands the command off with the same arguments,
-working directory, and exit behavior. Warm caches work offline. This applies to
-local install/add, uninstall, update, rebuild, and deps commands; scripts,
-`ut x`, query commands, and global installs keep using the current executable.
-Set `UTOO_SELF_PIN=0` to bypass the handoff temporarily.
+`~/.cache/nm/self/<version>@<platform>`, and hands the command off with the same
+arguments, working directory, and exit behavior. Warm caches work offline. An
+invalid cached release is never executed and is reprovisioned from the registry
+when available. This applies to local install/add, uninstall, update, rebuild,
+and deps commands; scripts, `ut x`, query commands, and global installs keep
+using the current executable. Set `UTOO_SELF_PIN=0` to bypass the handoff
+temporarily.
 
 #### Bundling via @utoo/pack-cli
 ```bash

--- a/README.md
+++ b/README.md
@@ -80,13 +80,14 @@ uses the same package-manager implementation:
 
 When a local dependency command runs with another Utoo version, Utoo downloads
 the matching supported platform package, verifies the registry checksum, caches
-it under `~/.cache/nm/_utoo-self-<platform>/<version>`, and hands the command off
-with the same arguments, working directory, and exit behavior. Warm caches work
-offline. An invalid cached release is never executed and is reprovisioned from
-the registry when available. This applies to local install/add, uninstall,
+it under `~/.cache/nm.utoo-self-pin/<platform>/<version>`, and hands the command
+off with the same arguments, working directory, and exit behavior. Warm caches
+work offline. An invalid cached release is never executed and is reprovisioned
+from the registry when available. This applies to local install/add, uninstall,
 update, rebuild, and deps commands; scripts, `ut x`, query commands, and global
 installs keep using the current executable. Set `UTOO_SELF_PIN=0` to bypass the
-handoff temporarily.
+handoff temporarily. These entries can be removed with, for example,
+`utoo clean _utoo-self-darwin-arm64@1.1.8`.
 
 #### Bundling via @utoo/pack-cli
 ```bash

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ uses the same package-manager implementation:
 ```
 
 When a local dependency command runs with another Utoo version, Utoo downloads
-the matching native release, verifies the registry checksum, caches it under
-`~/.cache/nm/self-<platform>/<version>`, and hands the command off with the same
-arguments, working directory, and exit behavior. Warm caches work offline. An
-invalid cached release is never executed and is reprovisioned from the registry
-when available. This applies to local install/add, uninstall, update, rebuild,
-and deps commands; scripts, `ut x`, query commands, and global installs keep
-using the current executable. Set `UTOO_SELF_PIN=0` to bypass the handoff
-temporarily.
+the matching supported platform package, verifies the registry checksum, caches
+it under `~/.cache/nm/_utoo-self-<platform>/<version>`, and hands the command off
+with the same arguments, working directory, and exit behavior. Warm caches work
+offline. An invalid cached release is never executed and is reprovisioned from
+the registry when available. This applies to local install/add, uninstall,
+update, rebuild, and deps commands; scripts, `ut x`, query commands, and global
+installs keep using the current executable. Set `UTOO_SELF_PIN=0` to bypass the
+handoff temporarily.
 
 #### Bundling via @utoo/pack-cli
 ```bash

--- a/crates/pm/src/cli.rs
+++ b/crates/pm/src/cli.rs
@@ -102,6 +102,27 @@ pub struct Cli {
     pub script_args: Vec<String>,
 }
 
+impl Cli {
+    /// Whether this invocation mutates or materializes the current project's
+    /// dependency state and should therefore honor its `packageManager` pin.
+    pub const fn uses_project_package_manager(&self) -> bool {
+        if self.script_name.is_some() {
+            return false;
+        }
+        match &self.command {
+            None => true,
+            Some(Commands::Install(args)) => !args.global,
+            Some(
+                Commands::Uninstall { .. }
+                | Commands::Rebuild
+                | Commands::Deps { .. }
+                | Commands::Update(_),
+            ) => true,
+            Some(_) => false,
+        }
+    }
+}
+
 #[derive(Subcommand)]
 pub enum ConfigCommands {
     #[command(about = "Set a configuration value with the specified key")]
@@ -426,6 +447,39 @@ mod tests {
             result.is_ok(),
             "Should parse 'utoo install' as valid Install command"
         );
+    }
+
+    #[test]
+    fn project_package_manager_scope_only_covers_local_dependency_commands() {
+        for args in [
+            vec!["utoo"],
+            vec!["utoo", "install"],
+            vec!["utoo", "add", "lodash"],
+            vec!["utoo", "uninstall", "lodash"],
+            vec!["utoo", "update"],
+            vec!["utoo", "rebuild"],
+            vec!["utoo", "deps"],
+        ] {
+            let cli = Cli::try_parse_from(args.clone()).unwrap();
+            assert!(
+                cli.uses_project_package_manager(),
+                "expected {args:?} to use the project package manager"
+            );
+        }
+
+        for args in [
+            vec!["utoo", "install", "lodash", "--global"],
+            vec!["utoo", "run", "test"],
+            vec!["utoo", "x", "eslint"],
+            vec!["utoo", "view", "react"],
+            vec!["utoo", "test"],
+        ] {
+            let cli = Cli::try_parse_from(args.clone()).unwrap();
+            assert!(
+                !cli.uses_project_package_manager(),
+                "expected {args:?} to keep using the running utoo"
+            );
+        }
     }
 
     #[test]

--- a/crates/pm/src/cmd/clean.rs
+++ b/crates/pm/src/cmd/clean.rs
@@ -31,8 +31,8 @@ pub async fn clean(pattern: &str, confirmation: ConfirmationPolicy) -> Result<()
 
     if !invocation::json() {
         println!("\nThe following caches will be deleted:");
-        for (pkg, version, _) in &to_delete {
-            println!("- {pkg}@{version}");
+        for entry in &to_delete {
+            println!("- {}@{}", entry.name, entry.version);
         }
 
         println!();
@@ -57,19 +57,22 @@ pub async fn clean(pattern: &str, confirmation: ConfirmationPolicy) -> Result<()
         }
         let deleted = deleted
             .into_iter()
-            .map(|(name, version, _)| PackageVersion { name, version })
+            .map(|entry| PackageVersion {
+                name: entry.name,
+                version: entry.version,
+            })
             .collect::<Vec<_>>();
-        if let Some(((name, version, path), error)) = failed.into_iter().next() {
+        if let Some((entry, error)) = failed.into_iter().next() {
             return Err(CliError::new(
                 ErrorKind::Local,
-                format!("failed to delete {name}@{version}: {error}"),
+                format!("failed to delete {}@{}: {error}", entry.name, entry.version),
             )
             .with_code("cache_delete_failed")
             .with_partial_result(PartialResult::Clean(CleanPartialResult {
                 deleted: deleted.clone(),
             }))
             .with_details(ErrorDetails::Filesystem {
-                path: path.to_string_lossy().into_owned(),
+                path: entry.path.to_string_lossy().into_owned(),
             })
             .into());
         }

--- a/crates/pm/src/helper/auto_update.rs
+++ b/crates/pm/src/helper/auto_update.rs
@@ -50,7 +50,9 @@ const UPDATE_RETRY_COOLDOWN_SECS: u64 = 86400; // 24 hours
 ///
 /// Either way this function returns quickly and never blocks the main command.
 pub async fn init_auto_update() {
-    if invocation::quiet() {
+    // A project-pinned child must stay on the requested release for the whole
+    // operation instead of replacing the user's global installation.
+    if invocation::quiet() || std::env::var_os("UTOO_SELF_PIN_VERSION").is_some() {
         return;
     }
 

--- a/crates/pm/src/helper/auto_update.rs
+++ b/crates/pm/src/helper/auto_update.rs
@@ -52,7 +52,7 @@ const UPDATE_RETRY_COOLDOWN_SECS: u64 = 86400; // 24 hours
 pub async fn init_auto_update() {
     // A project-pinned child must stay on the requested release for the whole
     // operation instead of replacing the user's global installation.
-    if invocation::quiet() || std::env::var_os("UTOO_SELF_PIN_VERSION").is_some() {
+    if invocation::quiet() || crate::helper::self_pin::is_active() {
         return;
     }
 

--- a/crates/pm/src/helper/lock.rs
+++ b/crates/pm/src/helper/lock.rs
@@ -192,6 +192,8 @@ pub struct ResolvedPackageSpec {
     pub version: String,
     pub version_spec: String,
     pub tarball_url: String,
+    pub integrity: Option<String>,
+    pub shasum: Option<String>,
 }
 
 pub async fn resolve_package_spec_details(spec: &str) -> Result<ResolvedPackageSpec> {
@@ -212,6 +214,8 @@ pub async fn resolve_package_spec_details(spec: &str) -> Result<ResolvedPackageS
                 version: resolved.version,
                 version_spec,
                 tarball_url,
+                integrity: resolved.manifest.dist.integrity.clone(),
+                shasum: resolved.manifest.dist.shasum.clone(),
             })
         }
         PackageSpec::Git { url, commit_ish } => {
@@ -221,6 +225,8 @@ pub async fn resolve_package_spec_details(spec: &str) -> Result<ResolvedPackageS
                 version: resolved.version.clone(),
                 version_spec: resolved.resolved_url.clone(),
                 tarball_url: resolved.resolved_url.clone(),
+                integrity: None,
+                shasum: None,
             })
         }
         PackageSpec::GitHub {
@@ -234,6 +240,8 @@ pub async fn resolve_package_spec_details(spec: &str) -> Result<ResolvedPackageS
                 version: resolved.version.clone(),
                 version_spec: resolved.resolved_url.clone(),
                 tarball_url: resolved.resolved_url.clone(),
+                integrity: None,
+                shasum: None,
             })
         }
         PackageSpec::Local { protocol, .. } => {

--- a/crates/pm/src/helper/mod.rs
+++ b/crates/pm/src/helper/mod.rs
@@ -21,5 +21,6 @@ pub mod global_bin;
 pub mod lock;
 pub mod migrate;
 pub mod ruborist_context;
+pub mod self_pin;
 pub mod tree_builder;
 pub mod workspace;

--- a/crates/pm/src/helper/self_pin.rs
+++ b/crates/pm/src/helper/self_pin.rs
@@ -95,7 +95,7 @@ pub async fn handoff_if_needed(
     let target = platform_target(std::env::consts::OS, std::env::consts::ARCH)?;
     let cache_path = release_cache_path_for(&target, &pin.version)?;
     let lock_path = sibling_lock_path(&cache_path, ".self-pin.lock")?;
-    let _lock = lock_exclusive(&lock_path).await?;
+    let lock = lock_exclusive(&lock_path).await?;
     let executable = match cached_release_at(&cache_path, &target, &pin.version).await? {
         CachedRelease::Valid(executable) => executable,
         CachedRelease::Missing => {
@@ -122,7 +122,7 @@ pub async fn handoff_if_needed(
             executable.display()
         );
     }
-    handoff(&executable, args, &pin.version)
+    handoff(&executable, args, &pin.version, lock)
 }
 
 pub fn is_active() -> bool {
@@ -398,7 +398,12 @@ async fn validate_executable_version(executable: &Path, version: &str) -> Result
 }
 
 #[cfg(unix)]
-fn handoff(executable: &Path, args: &[String], version: &str) -> Result<()> {
+fn handoff(
+    executable: &Path,
+    args: &[String],
+    version: &str,
+    _lock: crate::util::process_lock::ProcessLock,
+) -> Result<()> {
     use std::os::unix::process::CommandExt;
 
     let error = Command::new(executable)
@@ -410,13 +415,25 @@ fn handoff(executable: &Path, args: &[String], version: &str) -> Result<()> {
 }
 
 #[cfg(windows)]
-fn handoff(executable: &Path, args: &[String], version: &str) -> Result<()> {
-    let status = Command::new(executable)
+fn handoff(
+    executable: &Path,
+    args: &[String],
+    version: &str,
+    lock: crate::util::process_lock::ProcessLock,
+) -> Result<()> {
+    let mut child = Command::new(executable)
         .args(args)
         .env(HANDOFF_ENV, version)
         .env_remove("UTOO_MANAGED_PACKAGE_ROOT")
-        .status()
+        .spawn()
         .with_context(|| format!("Failed to start pinned Utoo at {}", executable.display()))?;
+    // Windows cannot replace the current process. Keep the slot stable until
+    // CreateProcess has opened the executable, then release it before waiting
+    // so the pinned child can run `utoo clean` without deadlocking its parent.
+    drop(lock);
+    let status = child
+        .wait()
+        .with_context(|| format!("Failed to wait for pinned Utoo at {}", executable.display()))?;
     std::process::exit(status.code().unwrap_or(1));
 }
 

--- a/crates/pm/src/helper/self_pin.rs
+++ b/crates/pm/src/helper/self_pin.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 
 use super::lock::resolve_package_spec_details;
 use crate::constants::APP_VERSION;
+#[cfg(test)]
 use crate::util::cache::get_cache_dir;
+use crate::util::cache::get_self_pin_cache_dir;
 use crate::util::downloader::download_bytes;
 use crate::util::extractor::extract_and_write;
 use crate::util::integrity::{compute_integrity, verify_integrity, verify_shasum};
@@ -91,7 +93,7 @@ pub async fn handoff_if_needed(
     set_cache_dir(cache_dir).await;
 
     let target = platform_target(std::env::consts::OS, std::env::consts::ARCH)?;
-    let cache_path = release_cache_path_for(&target, &pin.version);
+    let cache_path = release_cache_path_for(&target, &pin.version)?;
     let lock_path = sibling_lock_path(&cache_path, ".self-pin.lock")?;
     let _lock = lock_exclusive(&lock_path).await?;
     let executable = match cached_release_at(&cache_path, &target, &pin.version).await? {
@@ -220,12 +222,10 @@ fn platform_target(os: &str, arch: &str) -> Result<PlatformTarget> {
     Ok(target)
 }
 
-fn release_cache_path_for(target: &PlatformTarget, version: &str) -> PathBuf {
-    get_cache_dir()
-        // Leading underscores are rejected for registry package names, keeping
-        // this internal namespace disjoint from ordinary package cache slots.
-        .join(format!("_utoo-self-{}", target.cache_key))
-        .join(version)
+fn release_cache_path_for(target: &PlatformTarget, version: &str) -> Result<PathBuf> {
+    Ok(get_self_pin_cache_dir()?
+        .join(target.cache_key)
+        .join(version))
 }
 
 async fn cached_release_at(
@@ -523,12 +523,24 @@ mod tests {
         let windows_x64 = platform_target("windows", "x86_64").unwrap();
 
         assert_ne!(
-            release_cache_path_for(&mac_arm64, version),
-            release_cache_path_for(&mac_x64, version),
+            release_cache_path_for(&mac_arm64, version).unwrap(),
+            release_cache_path_for(&mac_x64, version).unwrap(),
         );
-        let mac_arm64_path = release_cache_path_for(&mac_arm64, version);
-        let mac_x64_path = release_cache_path_for(&mac_x64, version);
-        assert!(mac_arm64_path.ends_with("_utoo-self-darwin-arm64/1.1.8"));
+        let mac_arm64_path = release_cache_path_for(&mac_arm64, version).unwrap();
+        let mac_x64_path = release_cache_path_for(&mac_x64, version).unwrap();
+        assert!(mac_arm64_path.ends_with("darwin-arm64/1.1.8"));
+        assert_eq!(
+            mac_arm64_path.parent().unwrap().parent().unwrap(),
+            crate::util::cache::get_self_pin_cache_dir().unwrap(),
+        );
+        assert_ne!(
+            crate::util::cache::get_self_pin_cache_dir().unwrap(),
+            get_cache_dir(),
+        );
+        assert_ne!(
+            crate::util::package_cache::registry_cache_path("_utoo-self-darwin-arm64", version,),
+            mac_arm64_path,
+        );
         assert_ne!(
             sibling_lock_path(&mac_arm64_path, ".self-pin.lock").unwrap(),
             sibling_lock_path(&mac_x64_path, ".self-pin.lock").unwrap(),
@@ -536,28 +548,22 @@ mod tests {
         let legacy_path = get_cache_dir().join("self").join(version);
         assert_eq!(mac_arm64_path.file_name(), legacy_path.file_name());
         assert_ne!(mac_arm64_path, legacy_path);
-        let package = mac_arm64_path
-            .parent()
-            .unwrap()
-            .file_name()
-            .unwrap()
-            .to_string_lossy();
         let cached_version = mac_arm64_path.file_name().unwrap().to_string_lossy();
-        let cache_spec = format!("{package}@{cached_version}");
+        let cache_spec = format!("_utoo-self-{}@{cached_version}", mac_arm64.cache_key);
         assert_eq!(
             utoo_ruborist::util::parse_package_spec(&cache_spec),
             ("_utoo-self-darwin-arm64", "1.1.8"),
         );
         assert_eq!(
-            release_cache_path_for(&windows_arm64, version),
-            release_cache_path_for(&windows_x64, version),
+            release_cache_path_for(&windows_arm64, version).unwrap(),
+            release_cache_path_for(&windows_x64, version).unwrap(),
         );
     }
 
     #[tokio::test]
     async fn invalid_self_pin_metadata_requires_reprovision_without_early_deletion() {
         let temp = TempDir::new().unwrap();
-        let cache_path = temp.path().join("_utoo-self-darwin-arm64/1.1.8");
+        let cache_path = temp.path().join("self-pin/darwin-arm64/1.1.8");
         let package_root = cache_path.join("package");
         let target = platform_target("macos", "aarch64").unwrap();
         std::fs::create_dir_all(package_root.join("bin")).unwrap();
@@ -582,7 +588,7 @@ mod tests {
     #[tokio::test]
     async fn corrupt_self_pin_executable_requires_reprovision_without_execution() {
         let temp = TempDir::new().unwrap();
-        let cache_path = temp.path().join("_utoo-self-darwin-arm64/1.1.8");
+        let cache_path = temp.path().join("self-pin/darwin-arm64/1.1.8");
         let package_root = cache_path.join("package");
         let target = platform_target("macos", "aarch64").unwrap();
         std::fs::create_dir_all(package_root.join("bin")).unwrap();

--- a/crates/pm/src/helper/self_pin.rs
+++ b/crates/pm/src/helper/self_pin.rs
@@ -222,8 +222,8 @@ fn platform_target(os: &str, arch: &str) -> Result<PlatformTarget> {
 
 fn release_cache_path_for(target: &PlatformTarget, version: &str) -> PathBuf {
     get_cache_dir()
-        .join("self")
-        .join(format!("{version}@{}", target.cache_key))
+        .join(format!("self-{}", target.cache_key))
+        .join(version)
 }
 
 async fn cached_release_at(
@@ -526,14 +526,26 @@ mod tests {
         );
         let mac_arm64_path = release_cache_path_for(&mac_arm64, version);
         let mac_x64_path = release_cache_path_for(&mac_x64, version);
-        assert!(mac_arm64_path.ends_with("self/1.1.8@darwin-arm64"));
+        assert!(mac_arm64_path.ends_with("self-darwin-arm64/1.1.8"));
         assert_ne!(
             sibling_lock_path(&mac_arm64_path, ".self-pin.lock").unwrap(),
             sibling_lock_path(&mac_x64_path, ".self-pin.lock").unwrap(),
         );
         let legacy_path = get_cache_dir().join("self").join(version);
-        assert_eq!(mac_arm64_path.parent(), legacy_path.parent());
+        assert_eq!(mac_arm64_path.file_name(), legacy_path.file_name());
         assert_ne!(mac_arm64_path, legacy_path);
+        let package = mac_arm64_path
+            .parent()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_string_lossy();
+        let cached_version = mac_arm64_path.file_name().unwrap().to_string_lossy();
+        let cache_spec = format!("{package}@{cached_version}");
+        assert_eq!(
+            utoo_ruborist::util::parse_package_spec(&cache_spec),
+            ("self-darwin-arm64", "1.1.8"),
+        );
         assert_eq!(
             release_cache_path_for(&windows_arm64, version),
             release_cache_path_for(&windows_x64, version),
@@ -543,7 +555,7 @@ mod tests {
     #[tokio::test]
     async fn invalid_self_pin_metadata_requires_reprovision_without_early_deletion() {
         let temp = TempDir::new().unwrap();
-        let cache_path = temp.path().join("self/1.1.8@darwin-arm64");
+        let cache_path = temp.path().join("self-darwin-arm64/1.1.8");
         let package_root = cache_path.join("package");
         let target = platform_target("macos", "aarch64").unwrap();
         std::fs::create_dir_all(package_root.join("bin")).unwrap();
@@ -568,7 +580,7 @@ mod tests {
     #[tokio::test]
     async fn corrupt_self_pin_executable_requires_reprovision_without_execution() {
         let temp = TempDir::new().unwrap();
-        let cache_path = temp.path().join("self/1.1.8@darwin-arm64");
+        let cache_path = temp.path().join("self-darwin-arm64/1.1.8");
         let package_root = cache_path.join("package");
         let target = platform_target("macos", "aarch64").unwrap();
         std::fs::create_dir_all(package_root.join("bin")).unwrap();

--- a/crates/pm/src/helper/self_pin.rs
+++ b/crates/pm/src/helper/self_pin.rs
@@ -51,6 +51,14 @@ struct CacheMetadata {
 struct PlatformTarget {
     package_name: &'static str,
     executable: &'static str,
+    cache_key: &'static str,
+}
+
+#[derive(Debug)]
+enum CachedRelease {
+    Missing,
+    Valid(PathBuf),
+    Invalid(anyhow::Error),
 }
 
 /// Switch dependency-changing project commands to the exact Utoo version in
@@ -82,14 +90,28 @@ pub async fn handoff_if_needed(
     // `--from` migration), and unpinned invocations keep the existing order.
     set_cache_dir(cache_dir).await;
 
-    let cache_path = release_cache_path(&pin.version);
+    let target = platform_target(std::env::consts::OS, std::env::consts::ARCH)?;
+    let cache_path = release_cache_path_for(&target, &pin.version);
     let lock_path = sibling_lock_path(&cache_path, ".self-pin.lock")?;
     let _lock = lock_exclusive(&lock_path).await?;
-    let executable = if let Some(executable) = cached_release(&pin.version).await? {
-        executable
-    } else {
-        init_registry(registry).await?;
-        provision_release(&pin.version).await?
+    let executable = match cached_release_at(&cache_path, &target, &pin.version).await? {
+        CachedRelease::Valid(executable) => executable,
+        CachedRelease::Missing => {
+            init_registry(registry).await?;
+            provision_release_at(&cache_path, &target, &pin.version).await?
+        }
+        CachedRelease::Invalid(validation_error) => {
+            let recovery_context = format!(
+                "Failed to recover invalid pinned release cache at {} after validation failed: {validation_error:#}",
+                cache_path.display()
+            );
+            init_registry(registry)
+                .await
+                .context(recovery_context.clone())?;
+            provision_release_at(&cache_path, &target, &pin.version)
+                .await
+                .context(recovery_context)?
+        }
     };
     if !crate::util::invocation::quiet() {
         eprintln!(
@@ -170,51 +192,63 @@ fn platform_target(os: &str, arch: &str) -> Result<PlatformTarget> {
         ("macos", "x86_64") => PlatformTarget {
             package_name: "@utoo/utoo-darwin-x64",
             executable: "bin/utoo",
+            cache_key: "darwin-x64",
         },
         ("macos", "aarch64") => PlatformTarget {
             package_name: "@utoo/utoo-darwin-arm64",
             executable: "bin/utoo",
+            cache_key: "darwin-arm64",
         },
         ("linux", "x86_64") => PlatformTarget {
             package_name: "@utoo/utoo-linux-x64",
             executable: "bin/utoo",
+            cache_key: "linux-x64",
         },
         ("linux", "aarch64") => PlatformTarget {
             package_name: "@utoo/utoo-linux-arm64",
             executable: "bin/utoo",
+            cache_key: "linux-arm64",
         },
         // Windows 11 on ARM64 can run the published x64 binary under emulation.
         ("windows", "x86_64" | "aarch64") => PlatformTarget {
             package_name: "@utoo/utoo-win32-x64",
             executable: "bin/utoo.exe",
+            cache_key: "win32-x64",
         },
         _ => bail!("Utoo self-pinning does not support {os}-{arch}"),
     };
     Ok(target)
 }
 
-fn release_cache_path(version: &str) -> PathBuf {
-    get_cache_dir().join("self").join(version)
+fn release_cache_path_for(target: &PlatformTarget, version: &str) -> PathBuf {
+    get_cache_dir()
+        .join("self")
+        .join(format!("{version}@{}", target.cache_key))
 }
 
-async fn cached_release(version: &str) -> Result<Option<PathBuf>> {
-    let target = platform_target(std::env::consts::OS, std::env::consts::ARCH)?;
-    let cache_path = release_cache_path(version);
+async fn cached_release_at(
+    cache_path: &Path,
+    target: &PlatformTarget,
+    version: &str,
+) -> Result<CachedRelease> {
     if crate::fs::try_exists(cache_path.join("_resolved")).await?
         && crate::fs::try_exists(cache_path.join("_utoo-self-pin.json")).await?
     {
-        validate_cached_release(&cache_path, &target, version)
-            .await
-            .map(Some)
-    } else {
-        Ok(None)
+        return Ok(
+            match validate_cached_release(cache_path, target, version).await {
+                Ok(executable) => CachedRelease::Valid(executable),
+                Err(error) => CachedRelease::Invalid(error),
+            },
+        );
     }
+    Ok(CachedRelease::Missing)
 }
 
-async fn provision_release(version: &str) -> Result<PathBuf> {
-    let target = platform_target(std::env::consts::OS, std::env::consts::ARCH)?;
-    let cache_path = release_cache_path(version);
-
+async fn provision_release_at(
+    cache_path: &Path,
+    target: &PlatformTarget,
+    version: &str,
+) -> Result<PathBuf> {
     if !crate::util::invocation::quiet() {
         eprintln!("utoo: provisioning pinned utoo@{version}...");
     }
@@ -241,17 +275,18 @@ async fn provision_release(version: &str) -> Result<PathBuf> {
     )
     .with_context(|| format!("Failed to verify pinned release {spec}"))?;
 
-    // `_resolved` is the package-cache commit marker. Reaching the cold path
-    // with a visible slot means its self-pin metadata was never committed;
-    // clear it while holding the self-pin lock and repopulate atomically.
+    // `_resolved` is the package-cache commit marker. A visible slot on this
+    // path is invalid: archive download and registry checksum verification have
+    // already succeeded, so it is now safe to replace the slot atomically while
+    // holding the platform-specific self-pin lock.
     if crate::fs::try_exists(cache_path.join("_resolved")).await? {
-        crate::fs::remove_dir_all(&cache_path).await?;
+        crate::fs::remove_dir_all(cache_path).await?;
     }
-    extract_and_write(archive, &cache_path)
+    extract_and_write(archive, cache_path)
         .await
         .with_context(|| format!("Failed to cache pinned release {spec}"))?;
-    write_cache_metadata(&cache_path, &target, version).await?;
-    validate_cached_release(&cache_path, &target, version).await
+    write_cache_metadata(cache_path, target, version).await?;
+    validate_cached_release(cache_path, target, version).await
 }
 
 fn verify_release_archive(
@@ -463,6 +498,7 @@ mod tests {
             PlatformTarget {
                 package_name: "@utoo/utoo-darwin-arm64",
                 executable: "bin/utoo",
+                cache_key: "darwin-arm64",
             }
         );
         assert_eq!(
@@ -470,9 +506,95 @@ mod tests {
             PlatformTarget {
                 package_name: "@utoo/utoo-win32-x64",
                 executable: "bin/utoo.exe",
+                cache_key: "win32-x64",
             }
         );
         assert!(platform_target("freebsd", "x86_64").is_err());
+    }
+
+    #[test]
+    fn isolates_self_pin_caches_by_platform_package() {
+        let version = "1.1.8";
+        let mac_arm64 = platform_target("macos", "aarch64").unwrap();
+        let mac_x64 = platform_target("macos", "x86_64").unwrap();
+        let windows_arm64 = platform_target("windows", "aarch64").unwrap();
+        let windows_x64 = platform_target("windows", "x86_64").unwrap();
+
+        assert_ne!(
+            release_cache_path_for(&mac_arm64, version),
+            release_cache_path_for(&mac_x64, version),
+        );
+        let mac_arm64_path = release_cache_path_for(&mac_arm64, version);
+        let mac_x64_path = release_cache_path_for(&mac_x64, version);
+        assert!(mac_arm64_path.ends_with("self/1.1.8@darwin-arm64"));
+        assert_ne!(
+            sibling_lock_path(&mac_arm64_path, ".self-pin.lock").unwrap(),
+            sibling_lock_path(&mac_x64_path, ".self-pin.lock").unwrap(),
+        );
+        let legacy_path = get_cache_dir().join("self").join(version);
+        assert_eq!(mac_arm64_path.parent(), legacy_path.parent());
+        assert_ne!(mac_arm64_path, legacy_path);
+        assert_eq!(
+            release_cache_path_for(&windows_arm64, version),
+            release_cache_path_for(&windows_x64, version),
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_self_pin_metadata_requires_reprovision_without_early_deletion() {
+        let temp = TempDir::new().unwrap();
+        let cache_path = temp.path().join("self/1.1.8@darwin-arm64");
+        let package_root = cache_path.join("package");
+        let target = platform_target("macos", "aarch64").unwrap();
+        std::fs::create_dir_all(package_root.join("bin")).unwrap();
+        std::fs::write(cache_path.join("_resolved"), b"").unwrap();
+        std::fs::write(
+            package_root.join("package.json"),
+            r#"{"name":"@utoo/utoo-darwin-arm64","version":"1.1.8"}"#,
+        )
+        .unwrap();
+        std::fs::write(package_root.join("bin/utoo"), b"not executed").unwrap();
+        std::fs::write(cache_path.join("_utoo-self-pin.json"), b"not json").unwrap();
+
+        assert!(matches!(
+            cached_release_at(&cache_path, &target, "1.1.8")
+                .await
+                .unwrap(),
+            CachedRelease::Invalid(_)
+        ));
+        assert!(cache_path.exists());
+    }
+
+    #[tokio::test]
+    async fn corrupt_self_pin_executable_requires_reprovision_without_execution() {
+        let temp = TempDir::new().unwrap();
+        let cache_path = temp.path().join("self/1.1.8@darwin-arm64");
+        let package_root = cache_path.join("package");
+        let target = platform_target("macos", "aarch64").unwrap();
+        std::fs::create_dir_all(package_root.join("bin")).unwrap();
+        std::fs::write(cache_path.join("_resolved"), b"").unwrap();
+        std::fs::write(
+            package_root.join("package.json"),
+            r#"{"name":"@utoo/utoo-darwin-arm64","version":"1.1.8"}"#,
+        )
+        .unwrap();
+        std::fs::write(package_root.join("bin/utoo"), b"corrupt executable").unwrap();
+        std::fs::write(
+            cache_path.join("_utoo-self-pin.json"),
+            serde_json::to_vec(&CacheMetadata {
+                executable_integrity: compute_integrity(b"expected executable"),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            cached_release_at(&cache_path, &target, "1.1.8")
+                .await
+                .unwrap(),
+            CachedRelease::Invalid(_)
+        ));
+        assert!(cache_path.exists());
     }
 
     #[test]

--- a/crates/pm/src/helper/self_pin.rs
+++ b/crates/pm/src/helper/self_pin.rs
@@ -1,0 +1,482 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use bytes::Bytes;
+use deno_semver::Version;
+use serde::{Deserialize, Serialize};
+
+use super::lock::resolve_package_spec_details;
+use crate::constants::APP_VERSION;
+use crate::util::cache::get_cache_dir;
+use crate::util::downloader::download_bytes;
+use crate::util::extractor::extract_and_write;
+use crate::util::integrity::{compute_integrity, verify_integrity, verify_shasum};
+use crate::util::process_lock::{lock_exclusive, sibling_lock_path};
+use crate::util::user_config::{init_registry, set_cache_dir};
+
+pub const HANDOFF_ENV: &str = "UTOO_SELF_PIN_VERSION";
+const DISABLE_ENV: &str = "UTOO_SELF_PIN";
+// Earlier releases do not understand HANDOFF_ENV and may auto-update the
+// global installation while serving a pin. Limit pins to self-pin-aware builds.
+const MINIMUM_PINNED_VERSION: &str = "1.1.8";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProjectManifest {
+    package_manager: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ProjectPin {
+    manifest_path: PathBuf,
+    version: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseManifest {
+    name: String,
+    version: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CacheMetadata {
+    executable_integrity: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct PlatformTarget {
+    package_name: &'static str,
+    executable: &'static str,
+}
+
+/// Switch dependency-changing project commands to the exact Utoo version in
+/// the nearest ancestor `package.json` containing `packageManager: "utoo@…"`.
+///
+/// A successful handoff replaces the current process on Unix and exits with
+/// the child status on Windows, so this only returns when no switch is needed
+/// or provisioning fails.
+pub async fn handoff_if_needed(
+    cwd: &Path,
+    args: &[String],
+    registry: Option<String>,
+    cache_dir: Option<String>,
+) -> Result<()> {
+    if self_pin_disabled() {
+        return Ok(());
+    }
+    let Some(pin) = find_project_pin(cwd).await? else {
+        return Ok(());
+    };
+    validate_exact_version(&pin)?;
+    if pin.version == APP_VERSION || handoff_version().as_deref() == Some(pin.version.as_str()) {
+        return Ok(());
+    }
+
+    // Resolve the configured cache before network initialization so a warm pin
+    // remains fully offline. A pinned child owns normal startup (including
+    // `--from` migration), and unpinned invocations keep the existing order.
+    set_cache_dir(cache_dir).await;
+
+    let cache_path = release_cache_path(&pin.version);
+    let lock_path = sibling_lock_path(&cache_path, ".self-pin.lock")?;
+    let _lock = lock_exclusive(&lock_path).await?;
+    let executable = if let Some(executable) = cached_release(&pin.version).await? {
+        executable
+    } else {
+        init_registry(registry).await?;
+        provision_release(&pin.version).await?
+    };
+    if !crate::util::invocation::quiet() {
+        eprintln!(
+            "utoo: using pinned utoo@{} from {}",
+            pin.version,
+            executable.display()
+        );
+    }
+    handoff(&executable, args, &pin.version)
+}
+
+async fn find_project_pin(start: &Path) -> Result<Option<ProjectPin>> {
+    let mut current = start.to_path_buf();
+    loop {
+        let manifest_path = current.join("package.json");
+        match crate::fs::read_to_string(&manifest_path).await {
+            Ok(content) => {
+                let manifest: ProjectManifest = serde_json::from_str(&content)
+                    .with_context(|| format!("Failed to parse {}", manifest_path.display()))?;
+                if let Some(package_manager) = manifest.package_manager {
+                    return Ok(package_manager
+                        .strip_prefix("utoo@")
+                        .map(|version| ProjectPin {
+                            manifest_path,
+                            version: version.to_string(),
+                        }));
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("Failed to read {}", manifest_path.display()));
+            }
+        }
+        let Some(parent) = current.parent() else {
+            return Ok(None);
+        };
+        current = parent.to_path_buf();
+    }
+}
+
+fn self_pin_disabled() -> bool {
+    std::env::var(DISABLE_ENV).is_ok_and(|value| value == "0")
+}
+
+fn handoff_version() -> Option<String> {
+    std::env::var(HANDOFF_ENV).ok()
+}
+
+fn validate_exact_version(pin: &ProjectPin) -> Result<()> {
+    let version = Version::parse_from_npm(&pin.version)
+        .ok()
+        .filter(|version| version.to_string() == pin.version);
+    let Some(version) = version else {
+        bail!(
+            "{}: packageManager must pin an exact utoo version (for example, utoo@1.1.8)",
+            pin.manifest_path.display(),
+        );
+    };
+    let minimum = Version::parse_from_npm(MINIMUM_PINNED_VERSION)
+        .expect("minimum pinned version must be valid");
+    if version < minimum {
+        bail!(
+            "{}: packageManager self-pinning requires utoo@{} or newer",
+            pin.manifest_path.display(),
+            MINIMUM_PINNED_VERSION,
+        );
+    }
+    Ok(())
+}
+
+fn platform_target(os: &str, arch: &str) -> Result<PlatformTarget> {
+    let target = match (os, arch) {
+        ("macos", "x86_64") => PlatformTarget {
+            package_name: "@utoo/utoo-darwin-x64",
+            executable: "bin/utoo",
+        },
+        ("macos", "aarch64") => PlatformTarget {
+            package_name: "@utoo/utoo-darwin-arm64",
+            executable: "bin/utoo",
+        },
+        ("linux", "x86_64") => PlatformTarget {
+            package_name: "@utoo/utoo-linux-x64",
+            executable: "bin/utoo",
+        },
+        ("linux", "aarch64") => PlatformTarget {
+            package_name: "@utoo/utoo-linux-arm64",
+            executable: "bin/utoo",
+        },
+        // Windows 11 on ARM64 can run the published x64 binary under emulation.
+        ("windows", "x86_64" | "aarch64") => PlatformTarget {
+            package_name: "@utoo/utoo-win32-x64",
+            executable: "bin/utoo.exe",
+        },
+        _ => bail!("Utoo self-pinning does not support {os}-{arch}"),
+    };
+    Ok(target)
+}
+
+fn release_cache_path(version: &str) -> PathBuf {
+    get_cache_dir().join("self").join(version)
+}
+
+async fn cached_release(version: &str) -> Result<Option<PathBuf>> {
+    let target = platform_target(std::env::consts::OS, std::env::consts::ARCH)?;
+    let cache_path = release_cache_path(version);
+    if crate::fs::try_exists(cache_path.join("_resolved")).await?
+        && crate::fs::try_exists(cache_path.join("_utoo-self-pin.json")).await?
+    {
+        validate_cached_release(&cache_path, &target, version)
+            .await
+            .map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+async fn provision_release(version: &str) -> Result<PathBuf> {
+    let target = platform_target(std::env::consts::OS, std::env::consts::ARCH)?;
+    let cache_path = release_cache_path(version);
+
+    if !crate::util::invocation::quiet() {
+        eprintln!("utoo: provisioning pinned utoo@{version}...");
+    }
+    let spec = format!("{}@{version}", target.package_name);
+    let resolved = resolve_package_spec_details(&spec)
+        .await
+        .with_context(|| format!("Failed to resolve pinned release {spec}"))?;
+    if resolved.name != target.package_name || resolved.version != version {
+        bail!(
+            "Registry resolved {spec} as {}@{}",
+            resolved.name,
+            resolved.version
+        );
+    }
+
+    let token = crate::service::auth::token_for_url(&resolved.tarball_url).await;
+    let archive = download_bytes(&resolved.tarball_url, token.as_deref())
+        .await
+        .with_context(|| format!("Failed to download pinned release {spec}"))?;
+    verify_release_archive(
+        &archive,
+        resolved.integrity.as_deref(),
+        resolved.shasum.as_deref(),
+    )
+    .with_context(|| format!("Failed to verify pinned release {spec}"))?;
+
+    // `_resolved` is the package-cache commit marker. Reaching the cold path
+    // with a visible slot means its self-pin metadata was never committed;
+    // clear it while holding the self-pin lock and repopulate atomically.
+    if crate::fs::try_exists(cache_path.join("_resolved")).await? {
+        crate::fs::remove_dir_all(&cache_path).await?;
+    }
+    extract_and_write(archive, &cache_path)
+        .await
+        .with_context(|| format!("Failed to cache pinned release {spec}"))?;
+    write_cache_metadata(&cache_path, &target, version).await?;
+    validate_cached_release(&cache_path, &target, version).await
+}
+
+fn verify_release_archive(
+    archive: &Bytes,
+    integrity: Option<&str>,
+    shasum: Option<&str>,
+) -> Result<()> {
+    if let Some(integrity) = integrity {
+        return verify_integrity(archive, integrity);
+    }
+    if let Some(shasum) = shasum {
+        return verify_shasum(archive, shasum);
+    }
+    bail!("Registry response has neither dist.integrity nor dist.shasum")
+}
+
+async fn validate_cached_release(
+    cache_path: &Path,
+    target: &PlatformTarget,
+    version: &str,
+) -> Result<PathBuf> {
+    let package_root = cache_path.join("package");
+    let manifest_path = package_root.join("package.json");
+    let manifest: ReleaseManifest = serde_json::from_str(
+        &crate::fs::read_to_string(&manifest_path)
+            .await
+            .with_context(|| format!("Pinned release is missing {}", manifest_path.display()))?,
+    )
+    .with_context(|| format!("Failed to parse {}", manifest_path.display()))?;
+    if manifest.name != target.package_name || manifest.version != version {
+        bail!(
+            "Pinned release cache contains {}@{}, expected {}@{}",
+            manifest.name,
+            manifest.version,
+            target.package_name,
+            version
+        );
+    }
+
+    let executable = release_executable(cache_path, target).await?;
+    let metadata_path = cache_path.join("_utoo-self-pin.json");
+    let metadata: CacheMetadata = serde_json::from_str(
+        &crate::fs::read_to_string(&metadata_path)
+            .await
+            .with_context(|| format!("Pinned release is missing {}", metadata_path.display()))?,
+    )
+    .with_context(|| format!("Failed to parse {}", metadata_path.display()))?;
+    let executable_bytes = crate::fs::read(&executable).await?;
+    verify_integrity(&executable_bytes, &metadata.executable_integrity)
+        .with_context(|| format!("Pinned executable is corrupt: {}", executable.display()))?;
+    validate_executable_version(&executable, version).await?;
+    Ok(executable)
+}
+
+async fn write_cache_metadata(
+    cache_path: &Path,
+    target: &PlatformTarget,
+    version: &str,
+) -> Result<()> {
+    let executable = release_executable(cache_path, target).await?;
+    validate_executable_version(&executable, version).await?;
+    let metadata = CacheMetadata {
+        executable_integrity: compute_integrity(&crate::fs::read(&executable).await?),
+    };
+    let metadata_path = cache_path.join("_utoo-self-pin.json");
+    let staging_path = cache_path.join(format!("._utoo-self-pin.{}.tmp", std::process::id()));
+    crate::fs::write(&staging_path, serde_json::to_vec(&metadata)?).await?;
+    crate::fs::rename(&staging_path, &metadata_path)
+        .await
+        .with_context(|| format!("Failed to finalize pinned release cache for utoo@{version}"))
+}
+
+async fn release_executable(cache_path: &Path, target: &PlatformTarget) -> Result<PathBuf> {
+    let executable = cache_path.join("package").join(target.executable);
+    if !crate::fs::try_exists(&executable).await? {
+        bail!(
+            "Pinned release is missing executable {}",
+            executable.display()
+        );
+    }
+    Ok(executable)
+}
+
+async fn validate_executable_version(executable: &Path, version: &str) -> Result<()> {
+    let output = tokio::process::Command::new(executable)
+        .arg("--version")
+        .env(HANDOFF_ENV, version)
+        .env_remove("UTOO_MANAGED_PACKAGE_ROOT")
+        .output()
+        .await
+        .with_context(|| format!("Failed to inspect pinned Utoo at {}", executable.display()))?;
+    if !output.status.success() {
+        bail!(
+            "Pinned Utoo at {} failed its version check with {}",
+            executable.display(),
+            output.status
+        );
+    }
+    let actual = String::from_utf8(output.stdout).context("Pinned Utoo version is not UTF-8")?;
+    if actual.trim() != version {
+        bail!(
+            "Pinned executable reports utoo@{}, expected utoo@{version}",
+            actual.trim()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn handoff(executable: &Path, args: &[String], version: &str) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+
+    let error = Command::new(executable)
+        .args(args)
+        .env(HANDOFF_ENV, version)
+        .env_remove("UTOO_MANAGED_PACKAGE_ROOT")
+        .exec();
+    Err(error).with_context(|| format!("Failed to start pinned Utoo at {}", executable.display()))
+}
+
+#[cfg(windows)]
+fn handoff(executable: &Path, args: &[String], version: &str) -> Result<()> {
+    let status = Command::new(executable)
+        .args(args)
+        .env(HANDOFF_ENV, version)
+        .env_remove("UTOO_MANAGED_PACKAGE_ROOT")
+        .status()
+        .with_context(|| format!("Failed to start pinned Utoo at {}", executable.display()))?;
+    std::process::exit(status.code().unwrap_or(1));
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn finds_exact_utoo_pin_from_project_ancestor() {
+        let temp = TempDir::new().unwrap();
+        let nested = temp.path().join("packages/app");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            temp.path().join("package.json"),
+            r#"{"private":true,"packageManager":"utoo@1.0.6"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            find_project_pin(&nested).await.unwrap(),
+            Some(ProjectPin {
+                manifest_path: temp.path().join("package.json"),
+                version: "1.0.6".to_string(),
+            }),
+        );
+    }
+
+    #[tokio::test]
+    async fn nearest_explicit_package_manager_stops_ancestor_lookup() {
+        let temp = TempDir::new().unwrap();
+        let nested = temp.path().join("packages/app");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            temp.path().join("package.json"),
+            r#"{"packageManager":"utoo@1.1.7"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            nested.join("package.json"),
+            r#"{"packageManager":"pnpm@10.0.0"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(find_project_pin(&nested).await.unwrap(), None);
+    }
+
+    #[test]
+    fn accepts_only_exact_semver_pins() {
+        let manifest_path = PathBuf::from("package.json");
+        for version in ["1.1.8", "2.0.0-beta.1", "3.0.0+build.5"] {
+            assert!(
+                validate_exact_version(&ProjectPin {
+                    manifest_path: manifest_path.clone(),
+                    version: version.to_string(),
+                })
+                .is_ok(),
+                "expected {version} to be accepted"
+            );
+        }
+
+        for version in [
+            "latest", "^1.1.8", "~1.1.8", "1.x", "1.1", "v1.1.8", "1.1.7",
+        ] {
+            assert!(
+                validate_exact_version(&ProjectPin {
+                    manifest_path: manifest_path.clone(),
+                    version: version.to_string(),
+                })
+                .is_err(),
+                "expected {version} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn maps_release_packages_for_supported_targets() {
+        assert_eq!(
+            platform_target("macos", "aarch64").unwrap(),
+            PlatformTarget {
+                package_name: "@utoo/utoo-darwin-arm64",
+                executable: "bin/utoo",
+            }
+        );
+        assert_eq!(
+            platform_target("windows", "aarch64").unwrap(),
+            PlatformTarget {
+                package_name: "@utoo/utoo-win32-x64",
+                executable: "bin/utoo.exe",
+            }
+        );
+        assert!(platform_target("freebsd", "x86_64").is_err());
+    }
+
+    #[test]
+    fn requires_registry_checksum_metadata() {
+        let archive = Bytes::from_static(b"release archive");
+        let integrity = crate::util::integrity::compute_integrity(&archive);
+        let shasum = crate::util::integrity::compute_shasum(&archive);
+
+        assert!(verify_release_archive(&archive, Some(&integrity), None).is_ok());
+        assert!(verify_release_archive(&archive, None, Some(&shasum)).is_ok());
+        assert!(verify_release_archive(&archive, None, None).is_err());
+        assert!(verify_release_archive(&archive, Some("sha512-invalid"), None).is_err());
+    }
+}

--- a/crates/pm/src/helper/self_pin.rs
+++ b/crates/pm/src/helper/self_pin.rs
@@ -222,7 +222,9 @@ fn platform_target(os: &str, arch: &str) -> Result<PlatformTarget> {
 
 fn release_cache_path_for(target: &PlatformTarget, version: &str) -> PathBuf {
     get_cache_dir()
-        .join(format!("self-{}", target.cache_key))
+        // Leading underscores are rejected for registry package names, keeping
+        // this internal namespace disjoint from ordinary package cache slots.
+        .join(format!("_utoo-self-{}", target.cache_key))
         .join(version)
 }
 
@@ -277,8 +279,8 @@ async fn provision_release_at(
 
     // `_resolved` is the package-cache commit marker. A visible slot on this
     // path is invalid: archive download and registry checksum verification have
-    // already succeeded, so it is now safe to replace the slot atomically while
-    // holding the platform-specific self-pin lock.
+    // already succeeded, so it is now safe to repopulate the slot via an atomic
+    // cache commit while holding the platform-specific self-pin lock.
     if crate::fs::try_exists(cache_path.join("_resolved")).await? {
         crate::fs::remove_dir_all(cache_path).await?;
     }
@@ -526,7 +528,7 @@ mod tests {
         );
         let mac_arm64_path = release_cache_path_for(&mac_arm64, version);
         let mac_x64_path = release_cache_path_for(&mac_x64, version);
-        assert!(mac_arm64_path.ends_with("self-darwin-arm64/1.1.8"));
+        assert!(mac_arm64_path.ends_with("_utoo-self-darwin-arm64/1.1.8"));
         assert_ne!(
             sibling_lock_path(&mac_arm64_path, ".self-pin.lock").unwrap(),
             sibling_lock_path(&mac_x64_path, ".self-pin.lock").unwrap(),
@@ -544,7 +546,7 @@ mod tests {
         let cache_spec = format!("{package}@{cached_version}");
         assert_eq!(
             utoo_ruborist::util::parse_package_spec(&cache_spec),
-            ("self-darwin-arm64", "1.1.8"),
+            ("_utoo-self-darwin-arm64", "1.1.8"),
         );
         assert_eq!(
             release_cache_path_for(&windows_arm64, version),
@@ -555,7 +557,7 @@ mod tests {
     #[tokio::test]
     async fn invalid_self_pin_metadata_requires_reprovision_without_early_deletion() {
         let temp = TempDir::new().unwrap();
-        let cache_path = temp.path().join("self-darwin-arm64/1.1.8");
+        let cache_path = temp.path().join("_utoo-self-darwin-arm64/1.1.8");
         let package_root = cache_path.join("package");
         let target = platform_target("macos", "aarch64").unwrap();
         std::fs::create_dir_all(package_root.join("bin")).unwrap();
@@ -580,7 +582,7 @@ mod tests {
     #[tokio::test]
     async fn corrupt_self_pin_executable_requires_reprovision_without_execution() {
         let temp = TempDir::new().unwrap();
-        let cache_path = temp.path().join("self-darwin-arm64/1.1.8");
+        let cache_path = temp.path().join("_utoo-self-darwin-arm64/1.1.8");
         let package_root = cache_path.join("package");
         let target = platform_target("macos", "aarch64").unwrap();
         std::fs::create_dir_all(package_root.join("bin")).unwrap();

--- a/crates/pm/src/helper/self_pin.rs
+++ b/crates/pm/src/helper/self_pin.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::{Context, Result, bail};
 use bytes::Bytes;
@@ -20,6 +21,7 @@ const DISABLE_ENV: &str = "UTOO_SELF_PIN";
 // Earlier releases do not understand HANDOFF_ENV and may auto-update the
 // global installation while serving a pin. Limit pins to self-pin-aware builds.
 const MINIMUM_PINNED_VERSION: &str = "1.1.8";
+static SELF_PIN_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -71,6 +73,7 @@ pub async fn handoff_if_needed(
     };
     validate_exact_version(&pin)?;
     if pin.version == APP_VERSION || handoff_version().as_deref() == Some(pin.version.as_str()) {
+        SELF_PIN_ACTIVE.store(true, Ordering::Relaxed);
         return Ok(());
     }
 
@@ -96,6 +99,10 @@ pub async fn handoff_if_needed(
         );
     }
     handoff(&executable, args, &pin.version)
+}
+
+pub fn is_active() -> bool {
+    SELF_PIN_ACTIVE.load(Ordering::Relaxed) || std::env::var_os(HANDOFF_ENV).is_some()
 }
 
 async fn find_project_pin(start: &Path) -> Result<Option<ProjectPin>> {

--- a/crates/pm/src/main.rs
+++ b/crates/pm/src/main.rs
@@ -14,6 +14,7 @@ use crate::cmd::view::view;
 use crate::constants::{APP_NAME, APP_VERSION};
 use crate::error::{CliError, ErrorKind, classify};
 use crate::helper::auto_update::init_auto_update;
+use crate::helper::self_pin::handoff_if_needed;
 use crate::model::cli_output::{
     CompletionsResult, ErrorDetails, HelpResult, HelpTarget, InitResult, RequestedPackage,
     RequiredBy, VersionResult,
@@ -245,6 +246,16 @@ async fn async_main() -> Result<()> {
             println!("{APP_VERSION}");
             Ok(())
         });
+    }
+
+    if cli.uses_project_package_manager() {
+        handoff_if_needed(
+            &std::env::current_dir()?,
+            &args[1..],
+            cli.registry.clone(),
+            cli.cache_dir.clone(),
+        )
+        .await?;
     }
 
     // Handle completions early to avoid unnecessary initialization (tracing, registry, auto-update)

--- a/crates/pm/src/service/clean_cache.rs
+++ b/crates/pm/src/service/clean_cache.rs
@@ -4,7 +4,13 @@ use anyhow::Result;
 use utoo_ruborist::util::{PackageNameStr, parse_package_spec};
 
 use crate::fs;
-use crate::util::cache::{get_cache_dir, matches_pattern};
+use crate::util::cache::{get_cache_dir, get_self_pin_cache_dir, matches_pattern};
+
+const SELF_PIN_LOGICAL_PREFIX: &str = "_utoo-self-";
+
+fn reserves_self_pin_logical_namespace(pkg_pattern: &str) -> bool {
+    pkg_pattern.starts_with(SELF_PIN_LOGICAL_PREFIX)
+}
 
 /// A cache entry slated for deletion: (package name, version, on-disk path).
 pub type CacheEntry = (String, String, PathBuf);
@@ -36,7 +42,32 @@ async fn collect_matching_versions(
     Ok(())
 }
 
-/// Walk the global cache directory and collect entries matching `pattern`
+async fn collect_self_pin_cache_entries(
+    root: &std::path::Path,
+    pkg_pattern: &str,
+    version_pattern: &str,
+    to_delete: &mut Vec<CacheEntry>,
+) -> Result<()> {
+    if !fs::try_exists(root).await? {
+        return Ok(());
+    }
+    let mut targets = fs::read_dir(root).await?;
+    while let Some(target) = targets.next_entry().await? {
+        if !target.file_type().await?.is_dir() {
+            continue;
+        }
+        let target_name = target.file_name();
+        let logical_name = format!("{SELF_PIN_LOGICAL_PREFIX}{}", target_name.to_string_lossy());
+        if matches_pattern(&logical_name, pkg_pattern) {
+            collect_matching_versions(&target.path(), logical_name, version_pattern, to_delete)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+/// Walk the package cache and the dedicated self-pin cache root, collecting
+/// entries matching `pattern`
 /// (a `name[@version]` spec, both parts may contain wildcards).
 ///
 /// Handles scoped (`@scope/name`) and regular packages; the result is sorted
@@ -47,40 +78,53 @@ pub async fn collect_cache_entries(pattern: &str) -> Result<Vec<CacheEntry>> {
     let (pkg_pattern, version_pattern) = parse_package_spec(pattern);
     let mut to_delete = Vec::new();
 
-    // Read all package information
-    let mut entries = fs::read_dir(&cache_dir).await?;
-    while let Some(entry) = entries.next_entry().await? {
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
+    collect_self_pin_cache_entries(
+        &get_self_pin_cache_dir()?,
+        pkg_pattern,
+        version_pattern,
+        &mut to_delete,
+    )
+    .await?;
 
-        if name_str.is_scoped() {
-            // Handle scoped packages
-            let mut pkg_entries = fs::read_dir(entry.path()).await?;
-            while let Some(pkg_entry) = pkg_entries.next_entry().await? {
-                let pkg_name = pkg_entry.file_name();
-                let full_pkg_name = format!("{}/{}", name_str, pkg_name.to_string_lossy());
+    // The `_utoo-self-` prefix is reserved by this command for the logical
+    // view of the dedicated sibling root. This keeps exact clean operations
+    // from also deleting a permissive private-registry package with that name.
+    if !reserves_self_pin_logical_namespace(pkg_pattern) {
+        // Read all package information
+        let mut entries = fs::read_dir(&cache_dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
 
-                if matches_pattern(&full_pkg_name, pkg_pattern) {
-                    tracing::debug!("full pkg name {full_pkg_name}, pkg_pattern {pkg_pattern}");
+            if name_str.is_scoped() {
+                // Handle scoped packages
+                let mut pkg_entries = fs::read_dir(entry.path()).await?;
+                while let Some(pkg_entry) = pkg_entries.next_entry().await? {
+                    let pkg_name = pkg_entry.file_name();
+                    let full_pkg_name = format!("{}/{}", name_str, pkg_name.to_string_lossy());
+
+                    if matches_pattern(&full_pkg_name, pkg_pattern) {
+                        tracing::debug!("full pkg name {full_pkg_name}, pkg_pattern {pkg_pattern}");
+                        collect_matching_versions(
+                            &pkg_entry.path(),
+                            full_pkg_name,
+                            version_pattern,
+                            &mut to_delete,
+                        )
+                        .await?;
+                    }
+                }
+            } else {
+                // Handle regular packages
+                if matches_pattern(&name_str, pkg_pattern) {
                     collect_matching_versions(
-                        &pkg_entry.path(),
-                        full_pkg_name,
+                        &entry.path(),
+                        name_str.to_string(),
                         version_pattern,
                         &mut to_delete,
                     )
                     .await?;
                 }
-            }
-        } else {
-            // Handle regular packages
-            if matches_pattern(&name_str, pkg_pattern) {
-                collect_matching_versions(
-                    &entry.path(),
-                    name_str.to_string(),
-                    version_pattern,
-                    &mut to_delete,
-                )
-                .await?;
             }
         }
     }
@@ -189,6 +233,35 @@ mod tests {
             .await?;
 
         assert_eq!(to_delete.len(), 4);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_self_pin_versions_uses_clean_logical_names() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let self_pin_root = temp_dir.path().join("nm.utoo-self-pin");
+        fs::create_dir_all(self_pin_root.join("darwin-arm64/1.1.8")).await?;
+        fs::create_dir_all(self_pin_root.join("darwin-x64/1.1.8")).await?;
+        fs::write(self_pin_root.join("darwin-arm64/.1.1.8.self-pin.lock"), b"").await?;
+        let mut to_delete = Vec::new();
+
+        collect_self_pin_cache_entries(
+            &self_pin_root,
+            "_utoo-self-darwin-arm64",
+            "1.1.8",
+            &mut to_delete,
+        )
+        .await?;
+
+        assert_eq!(to_delete.len(), 1);
+        assert_eq!(to_delete[0].0, "_utoo-self-darwin-arm64");
+        assert_eq!(to_delete[0].1, "1.1.8");
+        assert_eq!(to_delete[0].2, self_pin_root.join("darwin-arm64/1.1.8"),);
+        assert!(reserves_self_pin_logical_namespace(
+            "_utoo-self-darwin-arm64"
+        ));
+        assert!(reserves_self_pin_logical_namespace("_utoo-self-*"));
+        assert!(!reserves_self_pin_logical_namespace("*"));
         Ok(())
     }
 }

--- a/crates/pm/src/service/clean_cache.rs
+++ b/crates/pm/src/service/clean_cache.rs
@@ -5,6 +5,7 @@ use utoo_ruborist::util::{PackageNameStr, parse_package_spec};
 
 use crate::fs;
 use crate::util::cache::{get_cache_dir, get_self_pin_cache_dir, matches_pattern};
+use crate::util::process_lock::{lock_exclusive, sibling_lock_path};
 
 const SELF_PIN_LOGICAL_PREFIX: &str = "_utoo-self-";
 
@@ -12,16 +13,28 @@ fn reserves_self_pin_logical_namespace(pkg_pattern: &str) -> bool {
     pkg_pattern.starts_with(SELF_PIN_LOGICAL_PREFIX)
 }
 
-/// A cache entry slated for deletion: (package name, version, on-disk path).
-pub type CacheEntry = (String, String, PathBuf);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CacheEntryKind {
+    Package,
+    SelfPin,
+}
+
+/// A cache entry slated for deletion.
+#[derive(Debug)]
+pub struct CacheEntry {
+    pub name: String,
+    pub version: String,
+    pub path: PathBuf,
+    kind: CacheEntryKind,
+}
 
 /// Collect every version directory of `pkg_name` under `path` whose version
-/// matches `version_pattern`, appending `(pkg_name, version, path)` to
-/// `to_delete`.
+/// matches `version_pattern`.
 async fn collect_matching_versions(
     path: &std::path::Path,
     pkg_name: String,
     version_pattern: &str,
+    kind: CacheEntryKind,
     to_delete: &mut Vec<CacheEntry>,
 ) -> Result<()> {
     let mut version_entries = fs::read_dir(path).await?;
@@ -32,11 +45,12 @@ async fn collect_matching_versions(
         let version = version_entry.file_name();
         let version_str = version.to_string_lossy();
         if matches_pattern(&version_str, version_pattern) {
-            to_delete.push((
-                pkg_name.clone(),
-                version_str.to_string(),
-                version_entry.path(),
-            ));
+            to_delete.push(CacheEntry {
+                name: pkg_name.clone(),
+                version: version_str.to_string(),
+                path: version_entry.path(),
+                kind,
+            });
         }
     }
     Ok(())
@@ -59,8 +73,14 @@ async fn collect_self_pin_cache_entries(
         let target_name = target.file_name();
         let logical_name = format!("{SELF_PIN_LOGICAL_PREFIX}{}", target_name.to_string_lossy());
         if matches_pattern(&logical_name, pkg_pattern) {
-            collect_matching_versions(&target.path(), logical_name, version_pattern, to_delete)
-                .await?;
+            collect_matching_versions(
+                &target.path(),
+                logical_name,
+                version_pattern,
+                CacheEntryKind::SelfPin,
+                to_delete,
+            )
+            .await?;
         }
     }
     Ok(())
@@ -72,14 +92,16 @@ async fn collect_self_pin_cache_entries(
 ///
 /// Handles scoped (`@scope/name`) and regular packages; the result is sorted
 /// by package name and version number.
-pub async fn collect_cache_entries(pattern: &str) -> Result<Vec<CacheEntry>> {
-    let cache_dir = get_cache_dir();
-
+async fn collect_cache_entries_at(
+    cache_dir: &std::path::Path,
+    self_pin_cache_dir: &std::path::Path,
+    pattern: &str,
+) -> Result<Vec<CacheEntry>> {
     let (pkg_pattern, version_pattern) = parse_package_spec(pattern);
     let mut to_delete = Vec::new();
 
     collect_self_pin_cache_entries(
-        &get_self_pin_cache_dir()?,
+        self_pin_cache_dir,
         pkg_pattern,
         version_pattern,
         &mut to_delete,
@@ -91,8 +113,15 @@ pub async fn collect_cache_entries(pattern: &str) -> Result<Vec<CacheEntry>> {
     // from also deleting a permissive private-registry package with that name.
     if !reserves_self_pin_logical_namespace(pkg_pattern) {
         // Read all package information
-        let mut entries = fs::read_dir(&cache_dir).await?;
-        while let Some(entry) = entries.next_entry().await? {
+        let mut entries = if fs::try_exists(&cache_dir).await? {
+            Some(fs::read_dir(&cache_dir).await?)
+        } else {
+            None
+        };
+        while let Some(entry) = match &mut entries {
+            Some(entries) => entries.next_entry().await?,
+            None => None,
+        } {
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
 
@@ -109,6 +138,7 @@ pub async fn collect_cache_entries(pattern: &str) -> Result<Vec<CacheEntry>> {
                             &pkg_entry.path(),
                             full_pkg_name,
                             version_pattern,
+                            CacheEntryKind::Package,
                             &mut to_delete,
                         )
                         .await?;
@@ -121,6 +151,7 @@ pub async fn collect_cache_entries(pattern: &str) -> Result<Vec<CacheEntry>> {
                         &entry.path(),
                         name_str.to_string(),
                         version_pattern,
+                        CacheEntryKind::Package,
                         &mut to_delete,
                     )
                     .await?;
@@ -130,9 +161,13 @@ pub async fn collect_cache_entries(pattern: &str) -> Result<Vec<CacheEntry>> {
     }
 
     // Sort by package name and version number
-    to_delete.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    to_delete.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.version.cmp(&b.version)));
 
     Ok(to_delete)
+}
+
+pub async fn collect_cache_entries(pattern: &str) -> Result<Vec<CacheEntry>> {
+    collect_cache_entries_at(&get_cache_dir(), &get_self_pin_cache_dir()?, pattern).await
 }
 
 /// Delete the given cache entries from global storage. Failures are logged
@@ -142,13 +177,36 @@ pub async fn delete_cache_entries(
 ) -> (Vec<CacheEntry>, Vec<(CacheEntry, std::io::Error)>) {
     let mut deleted = Vec::new();
     let mut failed = Vec::new();
-    for (pkg, version, path) in to_delete {
-        if let Err(e) = fs::remove_dir_all(&path).await {
-            tracing::error!("Failed to delete {pkg}@{version}: {e}");
-            failed.push(((pkg, version, path), e));
+    for entry in to_delete {
+        let _self_pin_lock = if entry.kind == CacheEntryKind::SelfPin {
+            let lock_result = match sibling_lock_path(&entry.path, ".self-pin.lock") {
+                Ok(lock_path) => lock_exclusive(&lock_path).await,
+                Err(error) => Err(error),
+            };
+            match lock_result {
+                Ok(lock) => Some(lock),
+                Err(e) => {
+                    let e = std::io::Error::other(e.to_string());
+                    tracing::error!(
+                        "Failed to lock {}@{} for deletion: {e}",
+                        entry.name,
+                        entry.version
+                    );
+                    failed.push((entry, e));
+                    continue;
+                }
+            }
         } else {
-            tracing::debug!("Deleted {pkg}@{version}");
-            deleted.push((pkg, version, path));
+            None
+        };
+        if let Err(e) = fs::remove_dir_all(&entry.path).await
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::error!("Failed to delete {}@{}: {e}", entry.name, entry.version);
+            failed.push((entry, e));
+        } else {
+            tracing::debug!("Deleted {}@{}", entry.name, entry.version);
+            deleted.push(entry);
         }
     }
     (deleted, failed)
@@ -182,13 +240,14 @@ mod tests {
             temp_dir.path(),
             "test-pkg".to_string(),
             "1.0.0",
+            CacheEntryKind::Package,
             &mut to_delete,
         )
         .await?;
 
         assert_eq!(to_delete.len(), 1);
-        assert_eq!(to_delete[0].0, "test-pkg");
-        assert_eq!(to_delete[0].1, "1.0.0");
+        assert_eq!(to_delete[0].name, "test-pkg");
+        assert_eq!(to_delete[0].version, "1.0.0");
         Ok(())
     }
 
@@ -201,13 +260,14 @@ mod tests {
             temp_dir.path(),
             "test-pkg".to_string(),
             "1.*",
+            CacheEntryKind::Package,
             &mut to_delete,
         )
         .await?;
 
         assert_eq!(to_delete.len(), 2);
-        assert!(to_delete.iter().any(|x| x.1 == "1.0.0"));
-        assert!(to_delete.iter().any(|x| x.1 == "1.0.1"));
+        assert!(to_delete.iter().any(|x| x.version == "1.0.0"));
+        assert!(to_delete.iter().any(|x| x.version == "1.0.1"));
         Ok(())
     }
 
@@ -216,8 +276,14 @@ mod tests {
         let temp_dir = TempDir::new()?;
         let mut to_delete = Vec::new();
 
-        collect_matching_versions(temp_dir.path(), "test-pkg".to_string(), "*", &mut to_delete)
-            .await?;
+        collect_matching_versions(
+            temp_dir.path(),
+            "test-pkg".to_string(),
+            "*",
+            CacheEntryKind::Package,
+            &mut to_delete,
+        )
+        .await?;
 
         assert_eq!(to_delete.len(), 0);
         Ok(())
@@ -229,8 +295,14 @@ mod tests {
         fs::write(temp_dir.path().join(".1.0.0.lock"), b"").await?;
         let mut to_delete = Vec::new();
 
-        collect_matching_versions(temp_dir.path(), "test-pkg".to_string(), "*", &mut to_delete)
-            .await?;
+        collect_matching_versions(
+            temp_dir.path(),
+            "test-pkg".to_string(),
+            "*",
+            CacheEntryKind::Package,
+            &mut to_delete,
+        )
+        .await?;
 
         assert_eq!(to_delete.len(), 4);
         Ok(())
@@ -254,14 +326,88 @@ mod tests {
         .await?;
 
         assert_eq!(to_delete.len(), 1);
-        assert_eq!(to_delete[0].0, "_utoo-self-darwin-arm64");
-        assert_eq!(to_delete[0].1, "1.1.8");
-        assert_eq!(to_delete[0].2, self_pin_root.join("darwin-arm64/1.1.8"),);
+        assert_eq!(to_delete[0].name, "_utoo-self-darwin-arm64");
+        assert_eq!(to_delete[0].version, "1.1.8");
+        assert_eq!(to_delete[0].kind, CacheEntryKind::SelfPin);
+        assert_eq!(to_delete[0].path, self_pin_root.join("darwin-arm64/1.1.8"),);
         assert!(reserves_self_pin_logical_namespace(
             "_utoo-self-darwin-arm64"
         ));
         assert!(reserves_self_pin_logical_namespace("_utoo-self-*"));
         assert!(!reserves_self_pin_logical_namespace("*"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_self_pin_versions_without_package_cache_root() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let package_cache = temp_dir.path().join("missing-nm");
+        let self_pin_root = temp_dir.path().join("missing-nm.utoo-self-pin");
+        fs::create_dir_all(self_pin_root.join("darwin-arm64/1.1.8")).await?;
+        let to_delete = collect_cache_entries_at(
+            &package_cache,
+            &self_pin_root,
+            "_utoo-self-darwin-arm64@1.1.8",
+        )
+        .await?;
+
+        assert!(!fs::try_exists(package_cache).await?);
+        assert_eq!(to_delete.len(), 1);
+        assert_eq!(to_delete[0].kind, CacheEntryKind::SelfPin);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_clean_wildcard_keeps_private_registry_entry_provenance() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let package_cache = temp_dir.path().join("nm");
+        let self_pin_root = temp_dir.path().join("nm.utoo-self-pin");
+        let version_path = package_cache.join("_utoo-self-private/1.0.0");
+        fs::create_dir_all(&version_path).await?;
+
+        let to_delete = collect_cache_entries_at(&package_cache, &self_pin_root, "*").await?;
+        assert_eq!(to_delete.len(), 1);
+        assert_eq!(to_delete[0].kind, CacheEntryKind::Package);
+
+        let (deleted, failed) = delete_cache_entries(to_delete).await;
+        assert_eq!(deleted.len(), 1);
+        assert!(failed.is_empty());
+        assert!(!fs::try_exists(&version_path).await?);
+        assert!(
+            !fs::try_exists(package_cache.join("_utoo-self-private/.1.0.0.self-pin.lock")).await?
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_self_pin_delete_waits_for_handoff_lock() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let version_path = temp_dir.path().join("darwin-arm64/1.1.8");
+        fs::create_dir_all(&version_path).await?;
+        let lock_path = sibling_lock_path(&version_path, ".self-pin.lock")?;
+        let handoff_lock = lock_exclusive(&lock_path).await?;
+
+        let entry = CacheEntry {
+            name: "_utoo-self-darwin-arm64".to_string(),
+            version: "1.1.8".to_string(),
+            path: version_path.clone(),
+            kind: CacheEntryKind::SelfPin,
+        };
+        let mut deletion = tokio::spawn(delete_cache_entries(vec![entry]));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), &mut deletion)
+                .await
+                .is_err(),
+            "clean unexpectedly completed while the handoff lock was held"
+        );
+        assert!(fs::try_exists(&version_path).await?);
+
+        drop(handoff_lock);
+        let (deleted, failed) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), deletion).await??;
+        assert_eq!(deleted.len(), 1);
+        assert!(failed.is_empty());
+        assert!(!fs::try_exists(&version_path).await?);
         Ok(())
     }
 }

--- a/crates/pm/src/util/cache.rs
+++ b/crates/pm/src/util/cache.rs
@@ -1,4 +1,33 @@
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
 pub use super::user_config::get_cache_dir;
+
+const SELF_PIN_CACHE_SUFFIX: &str = ".utoo-self-pin";
+
+/// Return the internal self-pin cache root as a sibling of the package cache.
+///
+/// Ordinary registry slots use the `<cache>/<name>/<version>` layout, so a
+/// sibling root cannot collide with a package slot merely because a private
+/// registry accepts an unusual package name. Keeping the configured cache path
+/// as the prefix preserves its filesystem/drive selection and relocation
+/// behavior.
+fn self_pin_cache_dir_for(cache_dir: &Path) -> Result<PathBuf> {
+    let cache_dir = std::path::absolute(cache_dir)
+        .with_context(|| format!("Failed to resolve cache directory {}", cache_dir.display()))?;
+    let name = cache_dir
+        .file_name()
+        .with_context(|| format!("Cache directory has no file name: {}", cache_dir.display()))?;
+    let mut self_pin_name = OsString::from(name);
+    self_pin_name.push(SELF_PIN_CACHE_SUFFIX);
+    Ok(cache_dir.with_file_name(self_pin_name))
+}
+
+pub fn get_self_pin_cache_dir() -> Result<PathBuf> {
+    self_pin_cache_dir_for(&get_cache_dir())
+}
 
 /// Glob-style match supporting `*` (any), `prefix*`, `*suffix`, `a*b`, and
 /// `@scope/*`. Shared by cache-clean version filtering and workspace filters.
@@ -99,5 +128,18 @@ mod tests {
         assert!(!matches_pattern("2.0.0", "1.*"));
         assert!(matches_pattern("1.0.0-beta", "1.0.0*"));
         assert!(!matches_pattern("1.0.1", "1.0.0*"));
+    }
+
+    #[test]
+    fn self_pin_cache_root_is_an_absolute_sibling() {
+        let package_cache = std::path::absolute("cache/nm").unwrap();
+        let self_pin_cache = self_pin_cache_dir_for(Path::new("cache/nm")).unwrap();
+
+        assert!(self_pin_cache.is_absolute());
+        assert_eq!(self_pin_cache.parent(), package_cache.parent());
+        assert_eq!(
+            self_pin_cache.file_name().unwrap(),
+            std::ffi::OsStr::new("nm.utoo-self-pin"),
+        );
     }
 }

--- a/crates/pm/src/util/integrity.rs
+++ b/crates/pm/src/util/integrity.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write as _;
 
+use anyhow::{Context, Result, bail};
 use base64::Engine;
 // sha1 and sha2 re-export the same `digest::Digest` trait; one anonymous
 // import covers both hashers.
@@ -21,6 +22,47 @@ pub fn compute_shasum(data: &[u8]) -> String {
         let _ = write!(s, "{b:02x}");
         s
     })
+}
+
+/// Verify npm Subresource Integrity metadata against downloaded bytes.
+///
+/// Registries may provide several whitespace-separated digests. A match from
+/// any supported algorithm is sufficient, following SRI semantics.
+pub fn verify_integrity(data: &[u8], integrity: &str) -> Result<()> {
+    let mut supported = false;
+    for token in integrity.split_ascii_whitespace() {
+        let Some((algorithm, encoded)) = token.split_once('-') else {
+            continue;
+        };
+        let actual = match algorithm {
+            "sha1" => sha1::Sha1::digest(data).to_vec(),
+            "sha256" => sha2::Sha256::digest(data).to_vec(),
+            "sha384" => sha2::Sha384::digest(data).to_vec(),
+            "sha512" => sha2::Sha512::digest(data).to_vec(),
+            _ => continue,
+        };
+        supported = true;
+        let expected = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .with_context(|| format!("Invalid {algorithm} integrity digest"))?;
+        if actual == expected {
+            return Ok(());
+        }
+    }
+
+    if !supported {
+        bail!("No supported checksum in integrity metadata: {integrity}");
+    }
+    bail!("Downloaded archive failed integrity verification")
+}
+
+/// Verify npm's legacy hexadecimal SHA-1 `dist.shasum` field.
+pub fn verify_shasum(data: &[u8], shasum: &str) -> Result<()> {
+    if compute_shasum(data).eq_ignore_ascii_case(shasum) {
+        Ok(())
+    } else {
+        bail!("Downloaded archive failed shasum verification")
+    }
 }
 
 #[cfg(test)]
@@ -72,5 +114,15 @@ mod tests {
         let a = compute_shasum(b"test data");
         let b = compute_shasum(b"test data");
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn verifies_registry_sri_and_rejects_corruption() {
+        let data = b"release archive";
+        let sri = compute_integrity(data);
+
+        assert!(verify_integrity(data, &sri).is_ok());
+        assert!(verify_integrity(b"corrupted", &sri).is_err());
+        assert!(verify_integrity(data, "md5-unsupported").is_err());
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/utooland/utoo/blob/next/README.md
-->

## Summary

Projects can now pin an exact Utoo package-manager version with `"packageManager": "utoo@x.y.z"`, so contributors and CI use the same implementation instead of whichever global Utoo version happens to be installed.

- Honor exact `packageManager` pins for local dependency operations.
- Provision the matching supported platform package from the configured npm registry.
- Verify registry SRI/shasum metadata, cache the release in a platform-specific slot under a dedicated self-pin cache root, and revalidate the cached executable and reported version before handoff.
- Treat invalid cached releases as cache misses: never execute them, and replace only the affected platform slot after a newly downloaded archive passes registry integrity verification.
- Preserve command arguments, working directory, stdio, exit status, and signals during handoff.
- Keep scripts, `ut x`, query commands, and global installs on the current executable.
- Document the pinning flow and the `UTOO_SELF_PIN=0` escape hatch.

Prior art: Nub provides the same project-level version selection through [`packageManager: "nub@x.y.z"`](https://nubjs.com/docs/pm#pinning-nub-itself), provisioning and handing off to the exact pinned Nub release during install operations.

SchemaStore support is being added in [SchemaStore/schemastore#6192](https://github.com/SchemaStore/schemastore/pull/6192). It updates the `package.json` schema pattern from:

```diff
-(npm|pnpm|yarn|bun|aube|nub)@\d+\.\d+\.\d+(-.+)?
+(npm|pnpm|yarn|bun|aube|nub|utoo)@\d+\.\d+\.\d+(-.+)?
```

The first release containing this feature should be `utoo@1.1.8` or newer; older binaries do not understand the recursion/auto-update guard used by the handoff.

## Test Plan

- `cargo test -p utoo-pm` — 369 unit tests and 28 CLI contract tests passed; 3 network tests ignored by the existing suite.
- Added regression coverage for platform-specific cache keys, malformed cache metadata, executable integrity mismatches, and self-pin cleanup serialization.
- Keep the self-pin cache physically isolated from ordinary registry packages while exposing logical `_utoo-self-<platform>@<version>` entries for exact `utoo clean` matching. Cleanup acquires the same platform/version lock as handoff and provisioning.
- On Windows, keep the slot locked through child process creation, then release it before waiting so nested `utoo clean` invocations cannot deadlock the handoff parent.
- `cargo clippy --all-targets -- -D warnings --no-deps`.
- `cargo fmt --all -- --check`.
- `npx tombi format --check`.
- `typos` on changed files.
- Manual corruption checks confirmed modified cached releases are never executed and fail closed if verified reprovisioning is unavailable.
