### PR TITLE
chore(wasm): update opfs-project to 0.2.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5019,9 +5019,9 @@ dependencies = [
 
 [[package]]
 name = "opfs-project"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a2d62fde0aad91700c1724f6cfefb4ef30ea7150db82cbd383da8264c57324"
+checksum = "a412851aeb669d0a5601df6e4cee1535904504c7fe6900929fff01ddba059bf1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/crates/utoo-wasm/Cargo.toml
+++ b/crates/utoo-wasm/Cargo.toml
@@ -16,7 +16,7 @@ flate2                   = "1.1.5"
 futures                  = { workspace = true }
 js-sys                   = "0.3.83"
 oneshot                  = "0.1.11"
-opfs-project             = "0.2.10"
+opfs-project             = "0.2.11"
 petgraph                 = "0.6"
 reqwest                  = { version = "0.12.22", default-features = false, features = ["json"] }
 rustc-hash               = { workspace = true }


### PR DESCRIPTION
## Summary
- Update `opfs-project` from 0.2.10 to 0.2.11 in `utoo-wasm`.
- Refresh the Cargo lockfile checksum for the new release.

## Changes
- Bump the direct dependency in `crates/utoo-wasm/Cargo.toml`.
- Resolve `Cargo.lock` to `opfs-project` 0.2.11.

## Validation
- `cargo check --offline -p utoo-wasm --target wasm32-unknown-unknown`
- Pre-push checks: Cargo formatting, TOML formatting, Biome, and typos.
- `git diff --check`

## Risk / rollout
- Low risk: patch-level dependency update limited to the WASM package.
- No migrations, configuration changes, or breaking API changes introduced by this PR.

## Reviewer notes
- Review the dependency resolution and WASM compatibility.