### PR TITLE
perf(pack): cross-compile Windows binding on Linux

### DIFF
--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -9,6 +9,7 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   PACK_NATIVE_BUILDER_IMAGE: utoo-pack-native-builder:release
+  PACK_WINDOWS_BUILDER_IMAGE: utoo-pack-windows-builder:release
 
 jobs:
   build:
@@ -68,11 +69,9 @@ jobs:
           #     git config --system core.longpaths true &&
           #     rustup target add aarch64-pc-windows-msvc &&
           #     npm run build:binding --workspace=@utoo/pack -- --target aarch64-pc-windows-msvc
-          - host: windows-latest
+          - host: ubuntu-latest
             binding: pack.win32-x64-msvc.node
-            build: |
-              git config --system core.longpaths true &&
-              npm run build:binding --workspace=@utoo/pack -- --target x86_64-pc-windows-msvc
+            windows_builder: true
             target: x86_64-pc-windows-msvc
     name: utoopack-release-${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}
@@ -93,7 +92,7 @@ jobs:
           sudo rm -rf /usr/share/miniconda
           sudo docker image prune --all --force
       - name: Set up Docker Buildx
-        if: matrix.settings.musl_builder
+        if: matrix.settings.musl_builder || matrix.settings.windows_builder
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           # Buildx requires this daemon-side entitlement for its isolated
@@ -111,6 +110,19 @@ jobs:
             --tag "$PACK_NATIVE_BUILDER_IMAGE" \
             --file scripts/pack-native-builder.Dockerfile \
             .
+      - name: Build Windows builder image
+        if: matrix.settings.windows_builder
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
+        env:
+          # The publish job downloads every artifact as a platform binding.
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
+        with:
+          context: .
+          file: scripts/pack-windows-builder.Dockerfile
+          load: true
+          provenance: false
+          tags: ${{ env.PACK_WINDOWS_BUILDER_IMAGE }}
+          cache-from: type=gha,scope=utoo-pack-windows-builder-v1
       - name: Init git submodules
         run: git submodule update --init --recursive --depth 1
       - name: Set up QEMU
@@ -128,7 +140,7 @@ jobs:
           package-manager-cache: false
       - name: Install
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        if: ${{ !matrix.settings.docker && !matrix.settings.musl_builder }}
+        if: ${{ !matrix.settings.docker && !matrix.settings.musl_builder && !matrix.settings.windows_builder }}
         with:
           toolchain: nightly-2026-07-29
           targets: ${{ matrix.settings.target }}
@@ -174,7 +186,7 @@ jobs:
             ${{ matrix.settings.docker }} \
             /bin/sh /build/build_script.sh
       - name: Verify NAPI CLI version
-        if: matrix.settings.musl_builder
+        if: matrix.settings.musl_builder || matrix.settings.windows_builder
         run: test "$(node -p 'require("@napi-rs/cli/package.json").version')" = "2.18.4"
       - name: Build musl binding
         if: matrix.settings.musl_builder
@@ -221,14 +233,52 @@ jobs:
           ! grep -Eq '/lib(64)?/(ld-linux|ld64)|ld-linux-' <<<"$program_headers"
       - name: Build
         run: ${{ matrix.settings.build }}
-        if: ${{ !matrix.settings.docker && !matrix.settings.musl_builder }}
+        if: ${{ !matrix.settings.docker && !matrix.settings.musl_builder && !matrix.settings.windows_builder }}
         shell: bash
+      - name: Build Windows binding
+        if: matrix.settings.windows_builder
+        env:
+          TARGET: ${{ matrix.settings.target }}
+        run: |
+          docker run --rm \
+            --env CI=1 \
+            --env CARGO_INCREMENTAL=0 \
+            --env CARGO_TERM_COLOR=always \
+            --env RUST_BACKTRACE=1 \
+            --env TARGET \
+            --volume "$GITHUB_WORKSPACE:/build" \
+            --workdir /build \
+            "$PACK_WINDOWS_BUILDER_IMAGE" \
+            /bin/bash /build/scripts/pack-windows-build.sh
+      - name: Check generated Windows binding files
+        if: matrix.settings.windows_builder
+        run: git diff --exit-code -- packages/pack/src/binding.js packages/pack/src/binding.d.ts
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pack-${{ matrix.settings.target }}
           path: ./packages/pack/src/${{ matrix.settings.binding }}
           if-no-files-found: error
+  verify-windows:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'utoopack-v')
+    name: Verify Windows binding - node@22
+    runs-on: windows-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pack-x86_64-pc-windows-msvc
+          path: binding
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.14.0
+          package-manager-cache: false
+      - name: Load Windows binding
+        shell: pwsh
+        run: |
+          $binding = (Resolve-Path "binding/pack.win32-x64-msvc.node").Path
+          node -e "const b=require(process.argv[1]); const p=process.env.RUNNER_TEMP+'\\utoo-pack-windows-smoke.lock'; const h=b.lockfileTryAcquireSync(p,'smoke'); if(!h) throw new Error('lock'); b.lockfileUnlockSync(h); console.log('loaded',process.platform,process.arch)" $binding
   publish:
     if: github.event_name == 'push' && startsWith(github.ref_name, 'utoopack-v')
     name: Publish
@@ -239,6 +289,7 @@ jobs:
       id-token: write
     needs:
       - build
+      - verify-windows
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:

--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -259,26 +259,6 @@ jobs:
           name: pack-${{ matrix.settings.target }}
           path: ./packages/pack/src/${{ matrix.settings.binding }}
           if-no-files-found: error
-  verify-windows:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'utoopack-v')
-    name: Verify Windows binding - node@22
-    runs-on: windows-latest
-    needs:
-      - build
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: pack-x86_64-pc-windows-msvc
-          path: binding
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
-        with:
-          node-version: 22.14.0
-          package-manager-cache: false
-      - name: Load Windows binding
-        shell: pwsh
-        run: |
-          $binding = (Resolve-Path "binding/pack.win32-x64-msvc.node").Path
-          node -e "const b=require(process.argv[1]); const p=process.env.RUNNER_TEMP+'\\utoo-pack-windows-smoke.lock'; const h=b.lockfileTryAcquireSync(p,'smoke'); if(!h) throw new Error('lock'); b.lockfileUnlockSync(h); console.log('loaded',process.platform,process.arch)" $binding
   publish:
     if: github.event_name == 'push' && startsWith(github.ref_name, 'utoopack-v')
     name: Publish
@@ -289,7 +269,6 @@ jobs:
       id-token: write
     needs:
       - build
-      - verify-windows
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:

--- a/.github/workflows/pack-windows-builder-cache.yml
+++ b/.github/workflows/pack-windows-builder-cache.yml
@@ -1,0 +1,46 @@
+name: utoopack-windows-builder-cache
+
+on:
+  push:
+    branches:
+      - next
+    paths:
+      - .github/workflows/pack-release.yml
+      - .github/workflows/pack-windows-builder-cache.yml
+      - scripts/pack-windows-builder.Dockerfile
+      - rust-toolchain.toml
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  warm-cache:
+    # Only trusted runs on the default branch may populate the shared cache.
+    if: github.ref == 'refs/heads/next'
+    name: Warm Windows builder cache
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: utoo-pack-windows-builder-cache
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          buildkitd-flags: --allow-insecure-entitlement=network.host
+          driver-opts: image=moby/buildkit@sha256:63db51c9b30208a7c2b1c40392c7ebb9ce2f85ba238a18a85420f8f5ea2d4684
+      - name: Warm builder cache
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
+        with:
+          context: .
+          file: scripts/pack-windows-builder.Dockerfile
+          outputs: type=cacheonly
+          provenance: false
+          cache-from: type=gha,scope=utoo-pack-windows-builder-v1
+          cache-to: type=gha,scope=utoo-pack-windows-builder-v1,mode=max

--- a/scripts/pack-windows-build.sh
+++ b/scripts/pack-windows-build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Cross-compile the @utoo/pack x86_64 Windows N-API binary on Linux.
+
+set -euo pipefail
+
+TARGET="${TARGET:-x86_64-pc-windows-msvc}"
+REPO_ROOT="${REPO_ROOT:-/build}"
+OUTPUT="packages/pack/src/pack.win32-x64-msvc.node"
+
+if [[ "$TARGET" != "x86_64-pc-windows-msvc" ]]; then
+  echo "unsupported TARGET: $TARGET" >&2
+  exit 2
+fi
+if [[ ! -d "$REPO_ROOT/.git" && ! -f "$REPO_ROOT/.git" ]]; then
+  echo "REPO_ROOT is not a Git worktree: $REPO_ROOT" >&2
+  exit 2
+fi
+
+cd "$REPO_ROOT"
+git config --global --add safe.directory "$REPO_ROOT"
+
+export CI="${CI:-true}"
+export CARGO_INCREMENTAL=0
+export CARGO_TERM_COLOR=always
+export XWIN_ARCH=x86_64
+export XWIN_VERSION=17
+export XWIN_SDK_VERSION=10.0.26100
+export XWIN_CRT_VERSION=14.44.17.14
+
+# napi-rs detects a Linux-to-Windows build and invokes cargo-xwin. cargo-xwin
+# resolves the repository's target rustflags and adds its SDK, CRT and lld-link
+# arguments without losing tokio_unstable or +crt-static.
+rm -f "$OUTPUT"
+
+node --version
+rustc --version
+cargo-xwin --version
+echo "Cross-compiling @utoo/pack for $TARGET"
+
+npm run build:binding --workspace=@utoo/pack -- --target "$TARGET"
+
+if [[ ! -s "$OUTPUT" ]]; then
+  echo "expected N-API binary was not produced: $OUTPUT" >&2
+  exit 1
+fi
+
+# Reject a wrong-architecture or malformed output before it reaches the npm
+# artifact. The release workflow then loads it on a Windows runner.
+PE_HEADER="$(llvm-readobj --file-header --coff-imports "$OUTPUT")"
+echo "$PE_HEADER"
+if ! grep -Eq 'Format: COFF-x86-64|Format:.*x86-64' <<<"$PE_HEADER"; then
+  echo "unexpected PE/COFF format: $OUTPUT" >&2
+  exit 1
+fi
+if ! grep -Eq 'Machine: IMAGE_FILE_MACHINE_AMD64 \(0x8664\)|Machine: AMD64' \
+  <<<"$PE_HEADER"; then
+  echo "unexpected PE/COFF machine: $OUTPUT" >&2
+  exit 1
+fi
+
+echo "Built $OUTPUT"

--- a/scripts/pack-windows-builder.Dockerfile
+++ b/scripts/pack-windows-builder.Dockerfile
@@ -1,0 +1,86 @@
+# Builder image for the x86_64 Windows MSVC variant of @utoo/pack.
+#
+# Build from the repository root so rust-toolchain.toml is available:
+#   docker build -f scripts/pack-windows-builder.Dockerfile \
+#     -t utoo-pack-windows-builder .
+#
+# Cargo and Node run natively on Linux. cargo-xwin supplies the Windows SDK
+# and MSVC CRT while clang-cl and Rust's bundled lld-link produce the PE/COFF
+# N-API binary.
+
+# The host image does not affect the Windows ABI. Pin the image used by this
+# experiment so a release cannot silently switch the build environment.
+FROM ubuntu:22.04@sha256:3b06811b2afd352be909dd088a004166d665dc76d38b13eada33522a9d915c6f AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    clang \
+    curl \
+    git \
+    libclang-dev \
+    lld \
+    llvm \
+    pkg-config \
+    xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node is a build tool only. Verify the official archive before installing it.
+ARG NODE_VERSION=22.14.0
+ARG NODE_SHA256=69b09dba5c8dcb05c4e4273a4340db1005abeafe3927efda2bc5b249e80437ec
+RUN curl -fsSLo /tmp/node.tar.xz \
+      "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+    echo "${NODE_SHA256}  /tmp/node.tar.xz" | sha256sum --check --strict && \
+    tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
+      --exclude CHANGELOG.md --exclude README.md && \
+    rm /tmp/node.tar.xz && \
+    node --version && npm --version
+
+# Match the repository's pinned Rust nightly and bake the Windows stdlib into
+# the image. A rust-toolchain.toml update invalidates this layer.
+COPY rust-toolchain.toml /tmp/rust-toolchain.toml
+RUN TOOLCHAIN=$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+      /tmp/rust-toolchain.toml) && \
+    test -n "$TOOLCHAIN" && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+      sh -s -- -y --default-toolchain "$TOOLCHAIN" --profile minimal && \
+    rm /tmp/rust-toolchain.toml
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN rustup target add x86_64-pc-windows-msvc
+
+# Use the prebuilt cargo-xwin binary from the version evaluated by Next.js in
+# vercel/next.js#92594. The checksum is published with that release.
+ARG CARGO_XWIN_VERSION=0.21.5
+ARG CARGO_XWIN_SHA256=42928296cfaaede33b85cc1b96c0db424070f32dfbd5c0a2abbd6d0d64f05334
+RUN curl --retry 5 --retry-all-errors -fsSLo /tmp/cargo-xwin.tar.gz \
+      "https://github.com/rust-cross/cargo-xwin/releases/download/v${CARGO_XWIN_VERSION}/cargo-xwin-v${CARGO_XWIN_VERSION}.x86_64-unknown-linux-musl.tar.gz" && \
+    echo "${CARGO_XWIN_SHA256}  /tmp/cargo-xwin.tar.gz" | sha256sum --check --strict && \
+    tar -xzf /tmp/cargo-xwin.tar.gz -C /root/.cargo/bin && \
+    rm /tmp/cargo-xwin.tar.gz && \
+    cargo-xwin --version
+
+# Ubuntu's LLD is too old for the MSVC loadcfg object used by cargo-xwin.
+# Rust's bundled rust-lld supports /guard:ehcont and selects the COFF flavor
+# from the lld-link executable name. cargo-xwin expects these LLVM tool names.
+RUN RUST_SYSROOT=$(rustc --print sysroot) && \
+    RUST_HOST=$(rustc -vV | sed -n 's/^host: //p') && \
+    ln -sf "$RUST_SYSROOT/lib/rustlib/$RUST_HOST/bin/rust-lld" \
+      /usr/local/bin/lld-link && \
+    ln -sf "$(command -v llvm-ar)" /usr/local/bin/llvm-lib && \
+    ln -sf "$(command -v clang)" /usr/local/bin/clang-cl && \
+    lld-link --version && clang-cl --version
+
+# Restrict the downloaded SDK/CRT payload to the only target Utoo publishes.
+# Pin the versions resolved from Microsoft's VS 17.14 release manifest so a
+# later manifest update cannot silently select a different toolchain.
+ENV XWIN_ARCH=x86_64 \
+    XWIN_VERSION=17 \
+    XWIN_SDK_VERSION=10.0.26100 \
+    XWIN_CRT_VERSION=14.44.17.14
+RUN cargo xwin cache xwin
+
+WORKDIR /build


### PR DESCRIPTION
## Summary

- cross-compile the `x86_64-pc-windows-msvc` N-API binding on an Ubuntu builder with `cargo-xwin`, clang-cl, and Rust bundled lld-link
- pin the Windows SDK `10.0.26100` and MSVC CRT `14.44.17.14`, and reuse the builder through the GitHub Actions BuildKit cache
- validate generated binding files and the PE/COFF AMD64 machine on Linux before uploading the exact `.node` artifact

Reference: vercel/next.js#92594 (open draft) — https://github.com/vercel/next.js/pull/92594

### Performance

| Path | Builder | Binding | Windows build job |
| --- | ---: | ---: | ---: |
| Previous native Windows median | — | 23m53s | 25m11s |
| Linux cross-build, cold builder | 13m39s | 11m47s | 27m27s |
| Linux cross-build, warm builder cache | 37s | 11m31s | 13m52s |

With a warm default-branch builder cache, the Windows job is about 45% faster end to end. The builder step falls from 13m39s to 37s; Rust binding compilation remains a cold release + Thin LTO build.

## Test Plan

- [x] `bash -n scripts/pack-windows-build.sh`
- [x] `dockerfilelint scripts/pack-windows-builder.Dockerfile`
- [x] Prettier/YAML/actionlint checks for `pack-release.yml`
- [x] full seven-platform `utoopack-release` workflow: https://github.com/utooland/utoo/actions/runs/31577806293
- [x] GHA builder cache warm run: https://github.com/utooland/utoo/actions/runs/31581489797
- [x] warm-cache release run: https://github.com/utooland/utoo/actions/runs/31584036044
- [x] PE/COFF `IMAGE_FILE_MACHINE_AMD64 (0x8664)` validation
- [x] one-off Windows Server 2025 / Node 22.14 `require()` plus lockfile acquire/release validation: https://github.com/utooland/utoo/actions/runs/31585679254
- [x] final clean-commit release run: https://github.com/utooland/utoo/actions/runs/31585679254
