### PR TITLE
feat(pack): support devServer.client.reconnect

### DIFF
--- a/crates/pack-core/js/src/hmr/client.ts
+++ b/crates/pack-core/js/src/hmr/client.ts
@@ -1,9 +1,15 @@
 // @ts-ignore
 import { connect } from "@vercel/turbopack-ecmascript-runtime/browser/dev/hmr-client/hmr-client";
-import { addMessageListener, connectHMR, sendMessage } from "./websocket";
+import {
+  addMessageListener,
+  connectHMR,
+  type HMRReconnect,
+  sendMessage,
+} from "./websocket";
 
 export function initHMR(
   chunkUpdateListenersGlobal = "TURBOPACK_CHUNK_UPDATE_LISTENERS",
+  reconnect: HMRReconnect = false,
 ) {
   connect({
     addMessageListener,
@@ -13,5 +19,6 @@ export function initHMR(
   });
   connectHMR({
     path: "/turbopack-hmr",
+    reconnect,
   });
 }

--- a/crates/pack-core/js/src/hmr/websocket.ts
+++ b/crates/pack-core/js/src/hmr/websocket.ts
@@ -12,6 +12,8 @@ type WebSocketMessage =
 let source: WebSocket | null = null;
 let eventCallbacks: Array<(event: WebSocketMessage) => void> = [];
 
+const RECONNECT_DELAYS_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
+
 // Helper function to dispatch messages to all event callbacks
 function dispatchMessage(message: WebSocketMessage) {
   for (const eventCallback of eventCallbacks) {
@@ -69,6 +71,9 @@ export interface HMROptions {
 
 let reloading = false;
 let serverSessionId: number | null = null;
+let hasConnected = false;
+let reconnectAttempt = 0;
+let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
 
 // This is not used by Next.js, but it is used by the standalone turbopack-cli
 export function connectHMR(options: HMROptions) {
@@ -78,6 +83,12 @@ export function connectHMR(options: HMROptions) {
     console.log("[HMR] connecting...");
 
     function handleOnline() {
+      hasConnected = true;
+      reconnectAttempt = 0;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = undefined;
+      }
       window.console.log("[HMR] connected");
 
       // Send the turbopack-connected message to trigger handleSocketConnected
@@ -159,6 +170,24 @@ export function connectHMR(options: HMROptions) {
       }
 
       window.console.warn("[HMR] disconnected");
+
+      // Do not retry a socket that never connected. Some proxy tools cannot
+      // forward HMR and would otherwise receive repeated connection attempts.
+      if (!hasConnected || reconnectTimer) {
+        return;
+      }
+
+      const reconnectDelay = RECONNECT_DELAYS_MS[reconnectAttempt];
+      if (reconnectDelay === undefined) {
+        window.console.warn("[HMR] reconnect attempts exhausted");
+        return;
+      }
+
+      reconnectAttempt++;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = undefined;
+        init();
+      }, reconnectDelay);
     }
 
     source = new WebSocket(`${getSocketUrl()}${options.path}`);

--- a/crates/pack-core/js/src/hmr/websocket.ts
+++ b/crates/pack-core/js/src/hmr/websocket.ts
@@ -67,13 +67,22 @@ function getSocketUrl() {
 
 export interface HMROptions {
   path: string;
+  reconnect?: HMRReconnect;
 }
+
+export type HMRReconnect = boolean | number;
 
 let reloading = false;
 let serverSessionId: number | null = null;
-let hasConnected = false;
 let reconnectAttempt = 0;
 let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+
+function getMaxReconnectAttempts(reconnect: HMRReconnect | undefined) {
+  if (reconnect === true) return Number.POSITIVE_INFINITY;
+  if (reconnect === false || reconnect === undefined) return 0;
+  if (!Number.isFinite(reconnect)) return 0;
+  return Math.max(0, Math.floor(reconnect));
+}
 
 // This is not used by Next.js, but it is used by the standalone turbopack-cli
 export function connectHMR(options: HMROptions) {
@@ -83,7 +92,6 @@ export function connectHMR(options: HMROptions) {
     console.log("[HMR] connecting...");
 
     function handleOnline() {
-      hasConnected = true;
       reconnectAttempt = 0;
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
@@ -171,13 +179,22 @@ export function connectHMR(options: HMROptions) {
 
       window.console.warn("[HMR] disconnected");
 
-      // Do not retry a socket that never connected. Some proxy tools cannot
-      // forward HMR and would otherwise receive repeated connection attempts.
-      if (!hasConnected || reconnectTimer) {
+      if (reconnectTimer) {
         return;
       }
 
-      const reconnectDelay = RECONNECT_DELAYS_MS[reconnectAttempt];
+      const maxReconnectAttempts = getMaxReconnectAttempts(options.reconnect);
+      if (reconnectAttempt >= maxReconnectAttempts) {
+        if (maxReconnectAttempts > 0) {
+          window.console.warn("[HMR] reconnect attempts exhausted");
+        }
+        return;
+      }
+
+      const reconnectDelay =
+        RECONNECT_DELAYS_MS[
+          Math.min(reconnectAttempt, RECONNECT_DELAYS_MS.length - 1)
+        ];
       if (reconnectDelay === undefined) {
         window.console.warn("[HMR] reconnect attempts exhausted");
         return;

--- a/crates/pack-core/src/client/context.rs
+++ b/crates/pack-core/src/client/context.rs
@@ -48,8 +48,8 @@ use crate::{
         runtime_entry::RuntimeEntries,
     },
     config::{
-        Config, OptionCompressType, ProviderConfig, default_max_chunk_count_per_group,
-        default_max_merge_chunk_size, default_min_chunk_size,
+        Config, HmrReconnect, OptionCompressType, ProviderConfig,
+        default_max_chunk_count_per_group, default_max_merge_chunk_size, default_min_chunk_size,
     },
     embed_js::embed_file_path,
     import_map::get_postcss_package_mapping,
@@ -203,9 +203,20 @@ pub async fn get_client_runtime_entries(
                 .as_ref()
                 .map_or("TURBOPACK", RcStr::as_str),
         );
+        let dev_server = config.dev_server().await?;
+        let reconnect_argument = dev_server
+            .client
+            .as_ref()
+            .and_then(|client| client.reconnect.as_ref())
+            .map(|reconnect| match reconnect {
+                HmrReconnect::Enabled(enabled) => format!(", {enabled}"),
+                HmrReconnect::Attempts(attempts) => format!(", {attempts}"),
+            })
+            .unwrap_or_default();
         let hmr_bootstrap = format!(
-            "import {{ initHMR }} from {hmr_client_path:?};\n\ninitHMR({});\n",
+            "import {{ initHMR }} from {hmr_client_path:?};\n\ninitHMR({}{});\n",
             serde_json::to_string(&chunk_update_listeners_global)?,
+            reconnect_argument,
         );
 
         runtime_entries.push(

--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -136,6 +136,22 @@ pub struct Entries(Vec<EntryOptions>);
 pub struct DevServer {
     pub hot: Option<bool>,
     pub dynamic_hmr_chunk_lists: Option<bool>,
+    pub client: Option<DevServerClient>,
+}
+
+#[turbo_tasks::value(eq = "manual")]
+#[derive(Clone, Debug, PartialEq, Default, Deserialize, OperationValue)]
+#[serde(rename_all = "camelCase")]
+pub struct DevServerClient {
+    pub reconnect: Option<HmrReconnect>,
+}
+
+#[turbo_tasks::value]
+#[derive(Clone, Debug, Deserialize, OperationValue)]
+#[serde(untagged)]
+pub enum HmrReconnect {
+    Enabled(bool),
+    Attempts(u32),
 }
 
 /// Provider configuration item - can be a module name string or [module, export] tuple.
@@ -2097,6 +2113,35 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_hmr_reconnect_deserialization() {
+        let enabled: Config = serde_json::from_value(serde_json::json!({
+            "entry": [],
+            "devServer": { "client": { "reconnect": true } }
+        }))
+        .unwrap();
+        assert!(matches!(
+            enabled
+                .dev_server
+                .and_then(|dev_server| dev_server.client)
+                .and_then(|client| client.reconnect),
+            Some(HmrReconnect::Enabled(true))
+        ));
+
+        let limited: Config = serde_json::from_value(serde_json::json!({
+            "entry": [],
+            "devServer": { "client": { "reconnect": 5 } }
+        }))
+        .unwrap();
+        assert!(matches!(
+            limited
+                .dev_server
+                .and_then(|dev_server| dev_server.client)
+                .and_then(|client| client.reconnect),
+            Some(HmrReconnect::Attempts(5))
+        ));
+    }
 
     #[test]
     fn test_server_entries_deserialization() {

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -242,6 +242,27 @@ pub struct SchemaDevServer {
     /// Register HMR chunk lists as dynamic chunks are loaded
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dynamic_hmr_chunk_lists: Option<bool>,
+
+    /// Browser-side development client options
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client: Option<SchemaDevServerClient>,
+}
+
+/// Browser-side development client options
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaDevServerClient {
+    /// Reconnect the HMR WebSocket. True retries indefinitely; a number limits attempts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reconnect: Option<SchemaHmrReconnect>,
+}
+
+/// HMR WebSocket reconnect policy
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum SchemaHmrReconnect {
+    Enabled(bool),
+    Attempts(u32),
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pack-shared/src/__test__/webpackCompat.test.ts
+++ b/packages/pack-shared/src/__test__/webpackCompat.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { compatOptionsFromWebpack, type WebpackConfig } from "../webpackCompat";
+
+describe("webpack dev server compatibility", () => {
+  it.each([true, false, 5])(
+    "preserves client reconnect value %s",
+    (reconnect) => {
+      const options = compatOptionsFromWebpack({
+        webpackMode: true,
+        entry: "./src/index.ts",
+        devServer: { client: { reconnect } },
+      } as WebpackConfig);
+
+      expect(options.config.devServer?.client?.reconnect).toBe(reconnect);
+    },
+  );
+});

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -200,6 +200,15 @@ export type ExternalConfig = string | ExternalAdvanced;
  */
 export type ProviderConfig = Record<string, string | [string, string]>;
 
+export interface DevServerClientConfig {
+  /**
+   * Reconnect the HMR WebSocket after it disconnects.
+   * `true` retries indefinitely, a number limits the retry count, and the
+   * default `false` preserves the current no-reconnect behavior.
+   */
+  reconnect?: boolean | number;
+}
+
 /**
  * Development server options (port, host, HTTPS, HMR).
  * Used by the dev server and by config resolution for startup options.
@@ -209,6 +218,8 @@ export interface DevServerConfig {
   hot?: boolean;
   /** Register HMR chunk lists as dynamic chunks are loaded. */
   dynamicHmrChunkLists?: boolean;
+  /** Browser-side development client options. */
+  client?: DevServerClientConfig;
   /** Port to listen on. */
   port?: number;
   /** Host to bind (e.g. localhost, 0.0.0.0). */

--- a/packages/pack-shared/src/webpackCompat.ts
+++ b/packages/pack-shared/src/webpackCompat.ts
@@ -758,6 +758,12 @@ function compatDevServer(devServer: any): ConfigComplete["devServer"] {
   if (typeof devServer.dynamicHmrChunkLists !== "undefined") {
     result.dynamicHmrChunkLists = !!devServer.dynamicHmrChunkLists;
   }
+  if (
+    typeof devServer.client?.reconnect === "boolean" ||
+    typeof devServer.client?.reconnect === "number"
+  ) {
+    result.client = { reconnect: devServer.client.reconnect };
+  }
   if (typeof devServer.port !== "undefined") {
     const p = Number(devServer.port);
     if (!Number.isNaN(p)) result.port = p;

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -667,6 +667,17 @@
       "description": "Development server configuration",
       "type": "object",
       "properties": {
+        "client": {
+          "description": "Browser-side development client options",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaDevServerClient"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "dynamicHmrChunkLists": {
           "description": "Register HMR chunk lists as dynamic chunks are loaded",
           "type": [
@@ -679,6 +690,23 @@
           "type": [
             "boolean",
             "null"
+          ]
+        }
+      }
+    },
+    "SchemaDevServerClient": {
+      "description": "Browser-side development client options",
+      "type": "object",
+      "properties": {
+        "reconnect": {
+          "description": "Reconnect the HMR WebSocket. True retries indefinitely; a number limits attempts.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaHmrReconnect"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       }
@@ -973,6 +1001,19 @@
           ]
         }
       }
+    },
+    "SchemaHmrReconnect": {
+      "description": "HMR WebSocket reconnect policy",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      ]
     },
     "SchemaHtmlConfig": {
       "description": "HTML generation configuration",

--- a/packages/pack/src/__test__/hmrWebSocketReconnect.test.ts
+++ b/packages/pack/src/__test__/hmrWebSocketReconnect.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type SocketCallback = ((event?: Event) => void) | null;
+
+class FakeWebSocket {
+  static readonly instances: FakeWebSocket[] = [];
+
+  readonly OPEN = 1;
+  readyState = 0;
+  onopen: SocketCallback = null;
+  onerror: SocketCallback = null;
+  onclose: SocketCallback = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  close() {}
+
+  send() {}
+}
+
+async function connectHmr() {
+  const { connectHMR } = await import(
+    "../../../../crates/pack-core/js/src/hmr/websocket"
+  );
+  connectHMR({ path: "/turbopack-hmr" });
+  return FakeWebSocket.instances[0];
+}
+
+describe("HMR WebSocket reconnect", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    FakeWebSocket.instances.length = 0;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    vi.stubGlobal("location", {
+      hostname: "localhost",
+      port: "3000",
+      protocol: "http:",
+    });
+    vi.stubGlobal("window", {
+      console: {
+        error: vi.fn(),
+        log: vi.fn(),
+        warn: vi.fn(),
+      },
+      location: { reload: vi.fn() },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not retry a socket that never connected", async () => {
+    const socket = await connectHmr();
+
+    socket.onerror?.({ target: socket } as unknown as Event);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  it("reconnects after an established socket disconnects", async () => {
+    const socket = await connectHmr();
+    socket.readyState = socket.OPEN;
+    socket.onopen?.();
+
+    socket.onclose?.({ target: socket } as unknown as Event);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(FakeWebSocket.instances[1].url).toBe(
+      "ws://localhost:3000/turbopack-hmr",
+    );
+  });
+
+  it("stops retrying after the bounded backoff is exhausted", async () => {
+    const socket = await connectHmr();
+    socket.readyState = socket.OPEN;
+    socket.onopen?.();
+
+    const retryDelays = [1_000, 2_000, 5_000, 10_000, 30_000];
+    for (const delay of retryDelays) {
+      const current = FakeWebSocket.instances.at(-1)!;
+      current.onclose?.({ target: current } as unknown as Event);
+      await vi.advanceTimersByTimeAsync(delay);
+    }
+
+    const finalAttempt = FakeWebSocket.instances.at(-1)!;
+    finalAttempt.onerror?.({ target: finalAttempt } as unknown as Event);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(FakeWebSocket.instances).toHaveLength(6);
+  });
+});

--- a/packages/pack/src/__test__/hmrWebSocketReconnect.test.ts
+++ b/packages/pack/src/__test__/hmrWebSocketReconnect.test.ts
@@ -21,11 +21,11 @@ class FakeWebSocket {
   send() {}
 }
 
-async function connectHmr() {
+async function connectHmr(reconnect?: boolean | number) {
   const { connectHMR } = await import(
     "../../../../crates/pack-core/js/src/hmr/websocket"
   );
-  connectHMR({ path: "/turbopack-hmr" });
+  connectHMR({ path: "/turbopack-hmr", reconnect });
   return FakeWebSocket.instances[0];
 }
 
@@ -57,7 +57,7 @@ describe("HMR WebSocket reconnect", () => {
     vi.unstubAllGlobals();
   });
 
-  it("does not retry a socket that never connected", async () => {
+  it("does not reconnect by default", async () => {
     const socket = await connectHmr();
 
     socket.onerror?.({ target: socket } as unknown as Event);
@@ -66,38 +66,36 @@ describe("HMR WebSocket reconnect", () => {
     expect(FakeWebSocket.instances).toHaveLength(1);
   });
 
-  it("reconnects after an established socket disconnects", async () => {
-    const socket = await connectHmr();
-    socket.readyState = socket.OPEN;
-    socket.onopen?.();
+  it("reconnects only the configured number of times", async () => {
+    const socket = await connectHmr(2);
+    socket.onerror?.({ target: socket } as unknown as Event);
 
-    socket.onclose?.({ target: socket } as unknown as Event);
-    await vi.advanceTimersByTimeAsync(999);
-    expect(FakeWebSocket.instances).toHaveLength(1);
+    const retryDelays = [1_000, 2_000];
+    for (const delay of retryDelays) {
+      await vi.advanceTimersByTimeAsync(delay);
+      const current = FakeWebSocket.instances.at(-1)!;
+      current.onerror?.({ target: current } as unknown as Event);
+    }
 
-    await vi.advanceTimersByTimeAsync(1);
-    expect(FakeWebSocket.instances).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(FakeWebSocket.instances).toHaveLength(3);
     expect(FakeWebSocket.instances[1].url).toBe(
       "ws://localhost:3000/turbopack-hmr",
     );
   });
 
-  it("stops retrying after the bounded backoff is exhausted", async () => {
-    const socket = await connectHmr();
-    socket.readyState = socket.OPEN;
-    socket.onopen?.();
+  it("keeps reconnecting when explicitly enabled", async () => {
+    const socket = await connectHmr(true);
+    socket.onerror?.({ target: socket } as unknown as Event);
 
-    const retryDelays = [1_000, 2_000, 5_000, 10_000, 30_000];
+    const retryDelays = [1_000, 2_000, 5_000, 10_000, 30_000, 30_000];
     for (const delay of retryDelays) {
-      const current = FakeWebSocket.instances.at(-1)!;
-      current.onclose?.({ target: current } as unknown as Event);
       await vi.advanceTimersByTimeAsync(delay);
+      const current = FakeWebSocket.instances.at(-1)!;
+      current.onerror?.({ target: current } as unknown as Event);
     }
 
-    const finalAttempt = FakeWebSocket.instances.at(-1)!;
-    finalAttempt.onerror?.({ target: finalAttempt } as unknown as Event);
-    await vi.advanceTimersByTimeAsync(60_000);
-
-    expect(FakeWebSocket.instances).toHaveLength(6);
+    expect(FakeWebSocket.instances).toHaveLength(7);
   });
 });


### PR DESCRIPTION
## Summary

Support `devServer.client.reconnect` to control whether the browser reconnects after the HMR WebSocket disconnects.

### Configuration

```ts
devServer: {
  client: {
    reconnect: true,
  },
}
```

- Not configured or `false`: do not reconnect, preserving the current default behavior.
- `true`: keep reconnecting until the connection recovers.
- A number such as `5`: reconnect at most that many times.

Reconnect attempts use 1s, 2s, 5s, 10s, and 30s backoff intervals, then remain at 30s when continuous reconnect is enabled. Webpack-compatible configurations also pass through this option.

This allows an opened page to recover after a temporary network interruption or devServer restart. Once connected to a new server session, the page reloads once and can continue receiving subsequent HMR updates.

No new dependencies are introduced.

## Test Plan

- `npm test --workspace @utoo/pack`: 69 tests passed.
- `npm test --workspace @utoo/pack-shared`: 9 tests passed.
- `cargo test -p pack-core test_hmr_reconnect_deserialization` passed.
- `cargo clippy --all-targets -- -D warnings --no-deps` passed.
- `npm run build:local --workspace @utoo/pack` passed.
- Verified with Jinni `publish-config`: after stopping and restarting devServer, the HMR WebSocket reconnected; a subsequent source edit was applied through HMR without a manual refresh.