### PR TITLE
feat(pack): expose advanced JavaScript chunking

### DIFF
--- a/crates/pack-core/src/config.rs
+++ b/crates/pack-core/src/config.rs
@@ -1214,6 +1214,27 @@ pub struct SplitChunkConfig {
     /// This makes sure that code in big chunks is not duplicated in multiple chunks.
     #[serde(default = "default_max_merge_chunk_size")]
     pub max_merge_chunk_size: usize,
+
+    /// Weight the benefit of merging chunks for a single page load. Values are
+    /// accepted as `0.0..=1.0` and stored as an integer percentage.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_first_page_load_priority",
+        serialize_with = "serialize_first_page_load_priority"
+    )]
+    pub first_page_load_priority: Option<u32>,
+
+    /// Estimated cost of an additional request in bytes of uncompressed,
+    /// unminified code.
+    pub request_cost: Option<u64>,
+
+    /// Emit component chunks alongside merged production chunks.
+    #[serde(default)]
+    pub generate_component_chunks: bool,
+
+    /// Minimum size in bytes for a component chunk to be emitted independently.
+    #[serde(default = "default_min_component_chunk_size")]
+    pub min_component_chunk_size: usize,
 }
 
 impl From<&SplitChunkConfig> for ChunkingConfig {
@@ -1222,6 +1243,10 @@ impl From<&SplitChunkConfig> for ChunkingConfig {
             min_chunk_size: value.min_chunk_size,
             max_chunk_count_per_group: value.max_chunk_count_per_group,
             max_merge_chunk_size: value.max_merge_chunk_size,
+            first_page_load_priority: value.first_page_load_priority,
+            request_cost: value.request_cost,
+            generate_component_chunks: value.generate_component_chunks,
+            min_component_chunk_size: value.min_component_chunk_size,
             ..Default::default()
         }
     }
@@ -1237,6 +1262,30 @@ pub fn default_max_chunk_count_per_group() -> usize {
 
 pub fn default_max_merge_chunk_size() -> usize {
     200_000
+}
+
+pub fn default_min_component_chunk_size() -> usize {
+    20_000
+}
+
+fn deserialize_first_page_load_priority<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<f64>::deserialize(deserializer)?
+        .map(|priority| (priority.clamp(0.0, 1.0) * 100.0).round() as u32))
+}
+
+fn serialize_first_page_load_priority<S>(
+    value: &Option<u32>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    value
+        .map(|priority| priority as f64 / 100.0)
+        .serialize(serializer)
 }
 
 #[turbo_tasks::value(transparent)]
@@ -2097,6 +2146,31 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_split_chunk_config_maps_advanced_js_options() {
+        let config: SplitChunkConfig = serde_json::from_value(serde_json::json!({
+            "firstPageLoadPriority": 0.675,
+            "requestCost": 123_456,
+            "generateComponentChunks": true,
+            "minComponentChunkSize": 4096
+        }))
+        .unwrap();
+        let chunking_config = ChunkingConfig::from(&config);
+
+        assert_eq!(config.first_page_load_priority, Some(68));
+        assert_eq!(chunking_config.first_page_load_priority, Some(68));
+        assert_eq!(chunking_config.request_cost, Some(123_456));
+        assert!(chunking_config.generate_component_chunks);
+        assert_eq!(chunking_config.min_component_chunk_size, 4096);
+
+        let defaults: SplitChunkConfig = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(!defaults.generate_component_chunks);
+        assert_eq!(
+            defaults.min_component_chunk_size,
+            default_min_component_chunk_size()
+        );
+    }
 
     #[test]
     fn test_server_entries_deserialization() {

--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -768,6 +768,34 @@ pub struct SchemaSplitChunkConfig {
     #[serde(default = "default_max_merge_chunk_size")]
     #[schemars(description = "Maximum merge chunk size")]
     pub max_merge_chunk_size: usize,
+
+    /// First-page-load priority for JavaScript chunks
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(
+        description = "How heavily to weight merging chunks for a single page load, from 0 to 1. JavaScript chunks only."
+    )]
+    pub first_page_load_priority: Option<f64>,
+
+    /// Estimated request cost for JavaScript chunks
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(
+        description = "Estimated cost of an additional request in bytes of uncompressed, unminified code. JavaScript chunks only."
+    )]
+    pub request_cost: Option<u64>,
+
+    /// Whether to emit component chunks for JavaScript
+    #[serde(default)]
+    #[schemars(
+        description = "Whether to emit component chunks alongside merged production JavaScript chunks. Defaults to false."
+    )]
+    pub generate_component_chunks: bool,
+
+    /// Minimum component chunk size
+    #[serde(default = "default_min_component_chunk_size")]
+    #[schemars(
+        description = "Minimum size in bytes for a component chunk to be emitted independently. JavaScript chunks only. Defaults to 20000."
+    )]
+    pub min_component_chunk_size: usize,
 }
 
 /// CSS chunking configuration
@@ -815,6 +843,7 @@ pub struct SchemaCssChunkingGraphOptions {
 // Import defaults from pack-core
 pub use pack_core::config::{
     default_max_chunk_count_per_group, default_max_merge_chunk_size, default_min_chunk_size,
+    default_min_component_chunk_size,
 };
 
 // ---------------------------------------------------------------------------
@@ -1323,6 +1352,9 @@ mod tests {
         assert!(schema_str.contains("externals"));
         assert!(schema_str.contains("optimization"));
         assert!(schema_str.contains("concatenateModules"));
+        assert!(schema_str.contains("generateComponentChunks"));
+        assert!(schema_str.contains("firstPageLoadPriority"));
+        assert!(schema_str.contains("requestCost"));
         assert!(schema_str.contains("cssChunking"));
         assert!(schema_str.contains("html"));
         assert!(schema_str.contains("react"));

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/config.json
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/config.json
@@ -1,0 +1,29 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/entry-a.js",
+        "name": "entry-a"
+      },
+      {
+        "import": "input/entry-b.js",
+        "name": "entry-b"
+      }
+    ],
+    "optimization": {
+      "moduleIds": "named",
+      "minify": false,
+      "splitChunks": {
+        "js": {
+          "minChunkSize": 1000000,
+          "maxChunkCountPerGroup": 1,
+          "maxMergeChunkSize": 1000000,
+          "firstPageLoadPriority": 0.8,
+          "requestCost": 1000,
+          "generateComponentChunks": true,
+          "minComponentChunkSize": 0
+        }
+      }
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/input/entry-a.js
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/input/entry-a.js
@@ -1,0 +1,4 @@
+import { valueA } from "./value-a.js";
+import { valueB } from "./value-b.js";
+
+console.log("entry-a", valueA, valueB);

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/input/entry-b.js
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/input/entry-b.js
@@ -1,0 +1,4 @@
+import { valueB } from "./value-b.js";
+import { valueA } from "./value-a.js";
+
+console.log("entry-b", valueB, valueA);

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/input/value-a.js
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/input/value-a.js
@@ -1,0 +1,1 @@
+export const valueA = "component-a-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/input/value-b.js
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/input/value-b.js
@@ -1,0 +1,1 @@
+export const valueB = "component-b-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/entry-a.js
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/entry-a.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":[{"path":"input_4b970f1e.js","moduleChunks":["input_fb53ca8a.js","input_entry-a_ad12aa83.js"]}],"runtimeModuleIds":["[project]/chunking/component_chunks/input/entry-a.js [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/entry-a.js.map
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/entry-a.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/entry-b.js
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/entry-b.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":[{"path":"input_4200386d.js","moduleChunks":["input_fb53ca8a.js","input_entry-b_c3aee452.js"]}],"runtimeModuleIds":["[project]/chunking/component_chunks/input/entry-b.js [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/entry-b.js.map
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/entry-b.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_4200386d.js
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_4200386d.js
@@ -1,0 +1,34 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/chunking/component_chunks/input/entry-b.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$b$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/chunking/component_chunks/input/value-b.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$a$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/chunking/component_chunks/input/value-a.js [client] (ecmascript)");
+;
+;
+console.log("entry-b", __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$b$2e$js__$5b$client$5d$__$28$ecmascript$29$__["valueB"], __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$a$2e$js__$5b$client$5d$__$28$ecmascript$29$__["valueA"]);
+__turbopack_context__.s([]);
+}),
+"[project]/chunking/component_chunks/input/value-a.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const valueA = "component-a-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+__turbopack_context__.s([
+    "valueA",
+    0,
+    valueA
+]);
+}),
+"[project]/chunking/component_chunks/input/value-b.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const valueB = "component-b-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+__turbopack_context__.s([
+    "valueB",
+    0,
+    valueB
+]);
+}),
+]);
+
+//# sourceMappingURL=input_4200386d.js.map

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_4200386d.js.map
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_4200386d.js.map
@@ -1,0 +1,8 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/chunking/component_chunks/input/entry-b.js"],"sourcesContent":["import { valueB } from \"./value-b.js\";\nimport { valueA } from \"./value-a.js\";\n\nconsole.log(\"entry-b\", valueB, valueA);\n"],"names":["console","log"],"mappings":"AAAA;AACA;;;AAEAA,QAAQC,GAAG,CAAC,WAAW,yJAAM,EAAE,yJAAM"}},
+    {"offset": {"line": 14, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/chunking/component_chunks/input/value-a.js"],"sourcesContent":["export const valueA = \"component-a-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\";\n"],"names":["valueA"],"mappings":"AAAO,MAAMA,SAAS"}},
+    {"offset": {"line": 24, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/chunking/component_chunks/input/value-b.js"],"sourcesContent":["export const valueB = \"component-b-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\";\n"],"names":["valueB"],"mappings":"AAAO,MAAMA,SAAS"}}]
+}

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_4b970f1e.js
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_4b970f1e.js
@@ -1,0 +1,34 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/chunking/component_chunks/input/entry-a.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$a$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/chunking/component_chunks/input/value-a.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$b$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/chunking/component_chunks/input/value-b.js [client] (ecmascript)");
+;
+;
+console.log("entry-a", __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$a$2e$js__$5b$client$5d$__$28$ecmascript$29$__["valueA"], __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$b$2e$js__$5b$client$5d$__$28$ecmascript$29$__["valueB"]);
+__turbopack_context__.s([]);
+}),
+"[project]/chunking/component_chunks/input/value-a.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const valueA = "component-a-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+__turbopack_context__.s([
+    "valueA",
+    0,
+    valueA
+]);
+}),
+"[project]/chunking/component_chunks/input/value-b.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const valueB = "component-b-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+__turbopack_context__.s([
+    "valueB",
+    0,
+    valueB
+]);
+}),
+]);
+
+//# sourceMappingURL=input_4b970f1e.js.map

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_4b970f1e.js.map
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_4b970f1e.js.map
@@ -1,0 +1,8 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/chunking/component_chunks/input/entry-a.js"],"sourcesContent":["import { valueA } from \"./value-a.js\";\nimport { valueB } from \"./value-b.js\";\n\nconsole.log(\"entry-a\", valueA, valueB);\n"],"names":["console","log"],"mappings":"AAAA;AACA;;;AAEAA,QAAQC,GAAG,CAAC,WAAW,yJAAM,EAAE,yJAAM"}},
+    {"offset": {"line": 14, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/chunking/component_chunks/input/value-a.js"],"sourcesContent":["export const valueA = \"component-a-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\";\n"],"names":["valueA"],"mappings":"AAAO,MAAMA,SAAS"}},
+    {"offset": {"line": 24, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/chunking/component_chunks/input/value-b.js"],"sourcesContent":["export const valueB = \"component-b-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\";\n"],"names":["valueB"],"mappings":"AAAO,MAAMA,SAAS"}}]
+}

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_entry-a_ad12aa83.js
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_entry-a_ad12aa83.js
@@ -1,0 +1,14 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/chunking/component_chunks/input/entry-a.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$a$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/chunking/component_chunks/input/value-a.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$b$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/chunking/component_chunks/input/value-b.js [client] (ecmascript)");
+;
+;
+console.log("entry-a", __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$a$2e$js__$5b$client$5d$__$28$ecmascript$29$__["valueA"], __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$b$2e$js__$5b$client$5d$__$28$ecmascript$29$__["valueB"]);
+__turbopack_context__.s([]);
+}),
+]);
+
+//# sourceMappingURL=input_entry-a_ad12aa83.js.map

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_entry-a_ad12aa83.js.map
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_entry-a_ad12aa83.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/chunking/component_chunks/input/entry-a.js"],"sourcesContent":["import { valueA } from \"./value-a.js\";\nimport { valueB } from \"./value-b.js\";\n\nconsole.log(\"entry-a\", valueA, valueB);\n"],"names":["console","log"],"mappings":"AAAA;AACA;;;AAEAA,QAAQC,GAAG,CAAC,WAAW,yJAAM,EAAE,yJAAM"}}]
+}

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_entry-b_c3aee452.js
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_entry-b_c3aee452.js
@@ -1,0 +1,14 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/chunking/component_chunks/input/entry-b.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$b$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/chunking/component_chunks/input/value-b.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$a$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/chunking/component_chunks/input/value-a.js [client] (ecmascript)");
+;
+;
+console.log("entry-b", __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$b$2e$js__$5b$client$5d$__$28$ecmascript$29$__["valueB"], __TURBOPACK__imported__module__$5b$project$5d2f$chunking$2f$component_chunks$2f$input$2f$value$2d$a$2e$js__$5b$client$5d$__$28$ecmascript$29$__["valueA"]);
+__turbopack_context__.s([]);
+}),
+]);
+
+//# sourceMappingURL=input_entry-b_c3aee452.js.map

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_entry-b_c3aee452.js.map
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_entry-b_c3aee452.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/chunking/component_chunks/input/entry-b.js"],"sourcesContent":["import { valueB } from \"./value-b.js\";\nimport { valueA } from \"./value-a.js\";\n\nconsole.log(\"entry-b\", valueB, valueA);\n"],"names":["console","log"],"mappings":"AAAA;AACA;;;AAEAA,QAAQC,GAAG,CAAC,WAAW,yJAAM,EAAE,yJAAM"}}]
+}

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_fb53ca8a.js
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_fb53ca8a.js
@@ -1,0 +1,24 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/chunking/component_chunks/input/value-a.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const valueA = "component-a-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+__turbopack_context__.s([
+    "valueA",
+    0,
+    valueA
+]);
+}),
+"[project]/chunking/component_chunks/input/value-b.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const valueB = "component-b-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+__turbopack_context__.s([
+    "valueB",
+    0,
+    valueB
+]);
+}),
+]);
+
+//# sourceMappingURL=input_fb53ca8a.js.map

--- a/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_fb53ca8a.js.map
+++ b/crates/pack-tests/tests/snapshot/chunking/component_chunks/output/input_fb53ca8a.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/chunking/component_chunks/input/value-a.js"],"sourcesContent":["export const valueA = \"component-a-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\";\n"],"names":["valueA"],"mappings":"AAAO,MAAMA,SAAS"}},
+    {"offset": {"line": 14, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/chunking/component_chunks/input/value-b.js"],"sourcesContent":["export const valueB = \"component-b-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\";\n"],"names":["valueB"],"mappings":"AAAO,MAAMA,SAAS"}}]
+}

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -284,13 +284,32 @@ export interface ConfigComplete {
     /** Extract legal comments to `[file].LICENSE.txt` when minifying library output. */
     extractComments?: boolean;
     treeShaking?: boolean;
-    splitChunks?: Record<
-      "js" | "css",
-      {
-        minChunkSize?: number;
-        maxChunkCountPerGroup?: number;
-        maxMergeChunkSize?: number;
-      }
+    splitChunks?: Partial<
+      Record<
+        "js" | "css",
+        {
+          minChunkSize?: number;
+          maxChunkCountPerGroup?: number;
+          maxMergeChunkSize?: number;
+          /**
+           * Weight the benefit of merging chunks for a single page load, from 0 to 1.
+           * JavaScript chunks only.
+           */
+          firstPageLoadPriority?: number;
+          /**
+           * Estimated cost of an additional request in bytes of uncompressed,
+           * unminified code. JavaScript chunks only.
+           */
+          requestCost?: number;
+          /** Emit component chunks alongside merged production JavaScript chunks. */
+          generateComponentChunks?: boolean;
+          /**
+           * Minimum size in bytes for a component chunk to be emitted independently.
+           * JavaScript chunks only. Defaults to `20000`.
+           */
+          minComponentChunkSize?: number;
+        }
+      >
     >;
     cssChunking?: CssChunkingConfig;
     modularizeImports?: Record<

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -1862,6 +1862,19 @@
       "description": "Split chunk configuration",
       "type": "object",
       "properties": {
+        "firstPageLoadPriority": {
+          "description": "How heavily to weight merging chunks for a single page load, from 0 to 1. JavaScript chunks only.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "generateComponentChunks": {
+          "description": "Whether to emit component chunks alongside merged production JavaScript chunks. Defaults to false.",
+          "default": false,
+          "type": "boolean"
+        },
         "maxChunkCountPerGroup": {
           "description": "Maximum chunk count per group",
           "default": 40,
@@ -1881,6 +1894,22 @@
           "default": 50000,
           "type": "integer",
           "format": "uint",
+          "minimum": 0.0
+        },
+        "minComponentChunkSize": {
+          "description": "Minimum size in bytes for a component chunk to be emitted independently. JavaScript chunks only. Defaults to 20000.",
+          "default": 20000,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "requestCost": {
+          "description": "Estimated cost of an additional request in bytes of uncompressed, unminified code. JavaScript chunks only.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
           "minimum": 0.0
         }
       }


### PR DESCRIPTION
## Summary

- expose advanced JavaScript split-chunk controls under `optimization.splitChunks.js`: `firstPageLoadPriority`, `requestCost`, `generateComponentChunks`, and `minComponentChunkSize`
- preserve Next/Turbopack semantics by accepting `firstPageLoadPriority` as `0..1`, clamping it, and storing the Turbo Tasks value as an integer percentage
- keep component chunks disabled by default and use the upstream `20000` byte default for `minComponentChunkSize`
- make the TypeScript `splitChunks` keys partial so users can configure `js` without also declaring `css`
- add a multi-entry snapshot proving merged chunks emit `{ path, moduleChunks }` bootstrap metadata and standalone component chunk files
- intentionally omit `priorityBoost` because Utoo does not currently provide the priority-route metadata it needs to have an effect

## Test Plan

- [x] `cargo fmt --check`
- [x] `cargo test -p pack-core test_split_chunk_config_maps_advanced_js_options`
- [x] `cargo test -p pack-schema`
- [x] `cargo test -p pack-tests component_chunks`
- [x] `npx biome check packages/pack-shared/src/config.ts packages/pack/config_schema.json`
- [x] `cargo clippy --all-targets -- -D warnings --no-deps`
