### PR TITLE
fix(pack): enter Tokio runtime for NAPI subscriptions

### DIFF
--- a/crates/pack-napi/src/lib.rs
+++ b/crates/pack-napi/src/lib.rs
@@ -58,7 +58,7 @@ fn init() {
     };
 
     use tokio::runtime::Builder;
-    use turbo_tasks::panic_hooks::handle_panic;
+    use turbo_tasks::{panic_hooks::handle_panic, parallel::available_parallelism};
     use turbo_tasks_malloc::TurboMalloc;
 
     let prev_hook = take_hook();
@@ -70,6 +70,8 @@ fn init() {
     thread_local! {
         static LAST_SWC_ATOM_GC_TIME: RefCell<Option<Instant>> = const { RefCell::new(None) };
     }
+
+    let worker_threads = available_parallelism().map(|n| n.get()).unwrap_or(1);
 
     let rt = Builder::new_multi_thread()
         .enable_all()
@@ -83,12 +85,25 @@ fn init() {
                     *cell = Some(Instant::now());
                 }
             });
+            TurboMalloc::thread_park();
         })
+        .worker_threads(worker_threads)
+        // Avoid a limit on threads to avoid deadlocks due to usage of block_in_place
+        .max_blocking_threads(usize::MAX - worker_threads)
+        // Avoid the extra lifo slot to avoid stalling tasks when doing cpu-heavy work
         .disable_lifo_slot()
         .build()
         .unwrap();
     napi::bindgen_prelude::create_custom_tokio_runtime(rt);
 
+    // napi v2 permanently entered its tokio runtime context on the addon's main thread. Both
+    // these bindings and turbo-tasks (e.g. `PriorityRunner`) schedule tokio work from
+    // synchronous N-API calls and rely on that ambient context. napi v3 no longer provides it,
+    // so restore it: capture the runtime handle (this also forces napi to adopt the custom
+    // runtime registered above) and enter it for the lifetime of this thread.
+    //
+    // TODO: Leaking the guard keeps the runtime alive for the whole process, so tokio never shuts
+    // down. Fix the callers that rely on an ambient runtime handle so that this can be dropped.
     let handle =
         napi::bindgen_prelude::within_runtime_if_available(tokio::runtime::Handle::current);
     std::mem::forget(Box::leak(Box::new(handle)).enter());

--- a/crates/pack-napi/src/lib.rs
+++ b/crates/pack-napi/src/lib.rs
@@ -88,8 +88,4 @@ fn init() {
         .build()
         .unwrap();
     napi::bindgen_prelude::create_custom_tokio_runtime(rt);
-
-    let handle =
-        napi::bindgen_prelude::within_runtime_if_available(tokio::runtime::Handle::current);
-    std::mem::forget(Box::leak(Box::new(handle)).enter());
 }

--- a/crates/pack-napi/src/lib.rs
+++ b/crates/pack-napi/src/lib.rs
@@ -88,4 +88,8 @@ fn init() {
         .build()
         .unwrap();
     napi::bindgen_prelude::create_custom_tokio_runtime(rt);
+
+    let handle =
+        napi::bindgen_prelude::within_runtime_if_available(tokio::runtime::Handle::current);
+    std::mem::forget(Box::leak(Box::new(handle)).enter());
 }

--- a/crates/pack-napi/src/lockfile.rs
+++ b/crates/pack-napi/src/lockfile.rs
@@ -112,6 +112,8 @@ pub fn lockfile_unlock<'env>(
     env: &'env Env,
     #[napi(ts_arg_type = "{ __napiType: \"Lockfile\" }")] lockfile: ExternalRef<JsLockfile>,
 ) -> napi::Result<PromiseRaw<'env, ()>> {
+    // Take the owned inner out on the JS thread (the `ExternalRef` is `!Send`), then release the
+    // lock on the blocking pool so the unlink and close don't stall the Node.js event loop.
     let inner = take_lockfile_inner(&lockfile);
     env.spawn_future(async move {
         let Some(inner) = inner else {

--- a/crates/pack-napi/src/pack_api/endpoint.rs
+++ b/crates/pack-napi/src/pack_api/endpoint.rs
@@ -129,7 +129,7 @@ pub async fn endpoint_write_to_disk(
     })
 }
 
-#[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
+#[napi(async_runtime, ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn endpoint_server_changed_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: &External<ExternalEndpoint>,
@@ -168,7 +168,7 @@ pub fn endpoint_server_changed_subscribe(
     )
 }
 
-#[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
+#[napi(async_runtime, ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn endpoint_client_changed_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: &External<ExternalEndpoint>,

--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -726,7 +726,7 @@ pub async fn project_write_all_entrypoints_to_disk(
     })
 }
 
-#[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
+#[napi(async_runtime, ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn project_entrypoints_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
@@ -771,7 +771,7 @@ pub fn project_entrypoints_subscribe(
 }
 
 #[tracing::instrument(level = "debug", name = "get HMR events", skip(env, project, func))]
-#[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
+#[napi(async_runtime, ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn project_hmr_events(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
@@ -896,7 +896,7 @@ pub struct HmrIdentifiers {
     pub identifiers: Vec<String>,
 }
 
-#[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
+#[napi(async_runtime, ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn project_hmr_identifiers_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
@@ -996,7 +996,7 @@ impl From<UpdateInfo> for NapiUpdateInfo {
 /// the number of tasks that were executed.
 ///
 /// The signature of the `func` is `(update_message: UpdateMessage) => void`.
-#[napi]
+#[napi(async_runtime)]
 pub fn project_update_info_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,

--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -891,7 +891,7 @@ pub fn project_hmr_events(
     )
 }
 
-#[napi(object)]
+#[napi(object, object_from_js = false)]
 pub struct HmrIdentifiers {
     pub identifiers: Vec<String>,
 }
@@ -949,9 +949,9 @@ pub enum UpdateMessage {
     End(UpdateInfo),
 }
 
-#[napi(object)]
+#[napi(object, object_from_js = false)]
 pub struct NapiUpdateMessage {
-    pub update_type: String,
+    pub update_type: &'static str,
     pub value: Option<NapiUpdateInfo>,
 }
 
@@ -959,18 +959,18 @@ impl From<UpdateMessage> for NapiUpdateMessage {
     fn from(update_message: UpdateMessage) -> Self {
         match update_message {
             UpdateMessage::Start => NapiUpdateMessage {
-                update_type: "start".to_string(),
+                update_type: "start",
                 value: None,
             },
             UpdateMessage::End(info) => NapiUpdateMessage {
-                update_type: "end".to_string(),
+                update_type: "end",
                 value: Some(info.into()),
             },
         }
     }
 }
 
-#[napi(object)]
+#[napi(object, object_from_js = false)]
 pub struct NapiUpdateInfo {
     pub duration: u32,
     pub tasks: u32,

--- a/crates/pack-napi/src/pack_api/turbopack_ctx.rs
+++ b/crates/pack-napi/src/pack_api/turbopack_ctx.rs
@@ -37,13 +37,16 @@ pub struct NapiTurbopackCallbacks {
     // to all of our async entrypoints, and would be complicated by `FunctionRef` being `!Send` (I
     // think it could be `Send`, as long as `napi::Env` is checked at call-time, which it should be
     // anyways).
+    //
+    // `Weak = true` so this ThreadsafeFunction doesn't keep the Node.js event loop alive after
+    // shutdown.
     throw_turbopack_internal_error: ThreadsafeFunction<
         TurbopackInternalErrorOpts,
         (),
         TurbopackInternalErrorOpts,
         Status,
-        true,
-        true,
+        /* CalleeHandled */ true,
+        /* Weak */ true,
     >,
 }
 

--- a/crates/pack-napi/src/pack_api/utils.rs
+++ b/crates/pack-napi/src/pack_api/utils.rs
@@ -120,7 +120,7 @@ impl CompilationEvent for StartupCacheInvalidationEvent {
     }
 }
 
-#[napi]
+#[napi(async_runtime)]
 pub fn root_task_dispose(
     #[napi(ts_arg_type = "{ __napiType: \"RootTask\" }")] mut root_task: ExternalRef<RootTask>,
 ) -> napi::Result<()> {

--- a/crates/pack-napi/src/pack_api/utils.rs
+++ b/crates/pack-napi/src/pack_api/utils.rs
@@ -264,6 +264,8 @@ impl<T: ToNapiValue> ToNapiValue for TurbopackResult<T> {
     }
 }
 
+/// Starts a TurboTasks root task immediately, so synchronous NAPI callers must use
+/// `#[napi(async_runtime)]` to enter the Tokio runtime before calling this helper.
 pub fn subscribe<
     T: 'static + Send + Sync,
     F: Future<Output = Result<T>> + Send,

--- a/crates/pack-napi/src/worker_pool.rs
+++ b/crates/pack-napi/src/worker_pool.rs
@@ -2,7 +2,14 @@ use napi::{Status, bindgen_prelude::Unknown, threadsafe_function::ThreadsafeFunc
 use napi_derive::napi;
 use turbopack_node::worker_pool::{NapiTaskMessage, NapiWorkerCreation, NapiWorkerTermination};
 
-type FatalThreadsafeFunction<T> = ThreadsafeFunction<T, Unknown<'static>, T, Status, false, true>;
+type FatalThreadsafeFunction<T> = ThreadsafeFunction<
+    T,
+    Unknown<'static>,
+    T,
+    Status,
+    /* CalleeHandled */ false,
+    /* Weak */ true,
+>;
 
 #[napi]
 pub fn register_worker_scheduler(


### PR DESCRIPTION
## Summary

- Fix the NAPI-RS v3 Worker regression by entering the configured Tokio runtime for all synchronous TurboTasks subscription and disposal exports.
- Keep and align the Next.js process-lifetime runtime compatibility guard, including worker parallelism, an unrestricted blocking pool, allocator parking, and the disabled LIFO slot.
- Align output-only NAPI object declarations and update-message strings with the upstream next-swc migration.
- Document weak ThreadsafeFunction behavior and ExternalRef ownership across JavaScript and async boundaries.

Fixes #3315

## Test Plan

- `ut i`
- `npm run build:binding:local --workspace @utoo/pack`
- Native binding audit: load on the main thread and in a Worker, create a project, subscribe to entrypoints/HMR/update-info, receive initial results, dispose the root task, and shut down.
- Native lockfile sync/async and worker-pool boundary audit.
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings --no-deps`
- `npm test --workspace @utoo/pack` (12 files, 66 tests passed)
- `npx biome ci`
- `typos`