### PR TITLE
fix(pack): skip perf comments for fork PRs

### DIFF
--- a/.github/workflows/pack-perf.yml
+++ b/.github/workflows/pack-perf.yml
@@ -119,7 +119,12 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
       - name: Post PR Comment
-        if: steps.findPr.outputs.number
+        # Fork pull requests receive a read-only GITHUB_TOKEN, so keep the
+        # report in the job summary and artifact instead of attempting a write.
+        if: >
+          steps.findPr.outputs.number &&
+          (github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository)
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: utoopack-perf-report


### PR DESCRIPTION
## Summary

- skip the sticky performance-report comment for pull requests from forks
- preserve benchmark execution, the job summary, and uploaded trace artifacts
- keep comment publishing enabled for same-repository pull requests and push-triggered runs

## Root cause

GitHub downgrades GITHUB_TOKEN to read-only for fork pull requests. The performance workflow still attempted to create a PR comment, so the otherwise successful benchmark job failed with Resource not accessible by integration.

## Validation

- parsed .github/workflows/pack-perf.yml as YAML
- ran git diff --check
- verified the condition truth table for fork PRs, same-repository PRs, and push runs