### PR TITLE
fix(pack): detect NAPI build targets correctly

### DIFF
--- a/crates/pack-napi/build.rs
+++ b/crates/pack-napi/build.rs
@@ -4,6 +4,13 @@ extern crate napi_build;
 
 fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-env-changed=CI");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_FAMILY");
+    // Build-script cfgs describe the host that runs this script. Read Cargo's target cfg
+    // environment instead so cross-compilation emits linker arguments for the target.
+    let is_macos_target = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|value| value == "macos");
+    let is_linux_target = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|value| value == "linux");
+    let is_wasm_target = env::var("CARGO_CFG_TARGET_FAMILY").is_ok_and(|value| value == "wasm");
     let is_ci = env::var("CI").is_ok_and(|value| !value.is_empty());
 
     // Generates, stores build-time information as static values.
@@ -49,12 +56,12 @@ fn main() -> anyhow::Result<()> {
         _ => println!("cargo:warning=`git rev-parse HEAD` failed"),
     }
 
-    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-    napi_build::setup();
+    if !is_macos_target {
+        napi_build::setup();
+    }
 
-    // This is a workaround for napi always including a GCC specific flag.
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    {
+    // This is a workaround for napi always including a GCC-specific flag on macOS.
+    if is_macos_target {
         println!("cargo:rerun-if-env-changed=DEBUG_GENERATED_CODE");
         println!("cargo:rerun-if-env-changed=TYPE_DEF_TMP_PATH");
         println!("cargo:rerun-if-env-changed=CARGO_CFG_NAPI_RS_CLI_VERSION");
@@ -65,8 +72,9 @@ fn main() -> anyhow::Result<()> {
 
     // Resolve a potential linker issue for unit tests on linux
     // https://github.com/napi-rs/napi-rs/issues/1782
-    #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
-    println!("cargo:rustc-link-arg=-Wl,--warn-unresolved-symbols");
+    if is_linux_target && !is_wasm_target {
+        println!("cargo:rustc-link-arg=-Wl,--warn-unresolved-symbols");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Detect the Cargo target from `CARGO_CFG_TARGET_OS` and `CARGO_CFG_TARGET_FAMILY` in the NAPI build script.
- Apply the macOS linker workaround to every macOS target instead of the build host architecture.
- Avoid leaking Linux-only linker arguments into cross-compiled targets.

This follows the upstream Next.js fixes in vercel/next.js#93164 and vercel/next.js#97576.

## Test Plan

- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings --no-deps`
- `cargo build --features plugin -p pack-napi --profile release-local`
