### PR TITLE
fix(pack): use commit SHA for cache versioning

### DIFF
--- a/crates/pack-napi/build.rs
+++ b/crates/pack-napi/build.rs
@@ -11,7 +11,6 @@ fn main() -> anyhow::Result<()> {
     let is_macos_target = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|value| value == "macos");
     let is_linux_target = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|value| value == "linux");
     let is_wasm_target = env::var("CARGO_CFG_TARGET_FAMILY").is_ok_and(|value| value == "wasm");
-    let is_ci = env::var("CI").is_ok_and(|value| !value.is_empty());
 
     // Generates, stores build-time information as static values.
     // There are some places relying on correct values for this (i.e telemetry),
@@ -36,11 +35,7 @@ fn main() -> anyhow::Result<()> {
     // commit hash as a version is okay.
     let git = vergen_gitcl::GitclBuilder::default()
         .dirty(/* include_untracked */ true)
-        .describe(
-            /* tags */ true,
-            /* dirty */ !is_ci, // suppress the dirty suffix in CI
-            /* matches */ Some("v[0-9]*"), // find the last version tag
-        )
+        .sha(/* short */ true)
         .build()?;
     vergen_gitcl::Emitter::default()
         .add_instructions(&cargo)?

--- a/crates/pack-napi/src/pack_api/utils.rs
+++ b/crates/pack-napi/src/pack_api/utils.rs
@@ -38,7 +38,7 @@ pub fn create_turbo_tasks(
 ) -> Result<UtooTurboTasks> {
     Ok(if persistent_caching {
         let version_info = GitVersionInfo {
-            describe: env!("VERGEN_GIT_DESCRIBE"),
+            describe: env!("VERGEN_GIT_SHA"),
             dirty: option_env!("CI").is_none_or(|value| value.is_empty())
                 && env!("VERGEN_GIT_DIRTY") == "true",
         };


### PR DESCRIPTION
## Summary

- Version persistent Turbopack caches with the build commit short SHA.
- Stop depending on a reachable `v`-prefixed tag from the combined Utoo repository.
- Keep dirty-worktree handling unchanged.

This follows the upstream direction from vercel/next.js#93605 while keeping the Utoo adapter independent from npm release version plumbing.

## Test Plan

- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings --no-deps`
- `cargo build --features plugin -p pack-napi --profile release-local`
