### PR TITLE
fix(pack): align generated binding release versions

### DIFF
--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -166,6 +166,15 @@ jobs:
 
       - name: Install dependencies
         run: utoo install
+      - name: Resolve binding package version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" == utoopack-v* ]]; then
+            binding_version="${GITHUB_REF_NAME#utoopack-v}"
+          else
+            binding_version="$(node -p 'require("./packages/pack/package.json").version')"
+          fi
+          echo "npm_new_version=$binding_version" >> "$GITHUB_ENV"
       - name: Setup node x86
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
@@ -178,6 +187,7 @@ jobs:
           EOF
           chmod +x build_script.sh
           docker run --rm \
+            --env npm_new_version \
             -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db \
             -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache \
             -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index \
@@ -201,13 +211,11 @@ jobs:
             --env CARGO_TERM_COLOR=always \
             --env RUST_BACKTRACE=1 \
             --env TARGET \
+            --env npm_new_version \
             --volume "$GITHUB_WORKSPACE:/build" \
             --workdir /build \
             "$PACK_NATIVE_BUILDER_IMAGE" \
             /bin/bash /build/scripts/pack-native-build.sh
-      - name: Check generated binding files
-        if: matrix.settings.musl_builder
-        run: git diff --exit-code -- packages/pack/src/binding.js packages/pack/src/binding.d.ts
       - name: Verify musl ELF target and loader
         if: matrix.settings.musl_builder
         env:
@@ -246,13 +254,24 @@ jobs:
             --env CARGO_TERM_COLOR=always \
             --env RUST_BACKTRACE=1 \
             --env TARGET \
+            --env npm_new_version \
             --volume "$GITHUB_WORKSPACE:/build" \
             --workdir /build \
             "$PACK_WINDOWS_BUILDER_IMAGE" \
             /bin/bash /build/scripts/pack-windows-build.sh
-      - name: Check generated Windows binding files
-        if: matrix.settings.windows_builder
-        run: git diff --exit-code -- packages/pack/src/binding.js packages/pack/src/binding.d.ts
+      - name: Verify generated binding files
+        run: |
+          npm run check:binding-version --workspace=@utoo/pack -- "$npm_new_version"
+          git diff --exit-code -- packages/pack/src/binding.d.ts
+      - name: Upload binding loader
+        if: matrix.settings.target == 'aarch64-apple-darwin'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: napi-binding-loader
+          path: |
+            ./packages/pack/src/binding.js
+            ./packages/pack/src/binding.d.ts
+          if-no-files-found: error
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -290,9 +309,15 @@ jobs:
 
       - name: Install dependencies
         run: utoo install
-      - name: Download all artifacts
+      - name: Download native binding artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          pattern: pack-*
+          path: ./packages/pack/src
+      - name: Download binding loader
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: napi-binding-loader
           path: ./packages/pack/src
       - name: Move artifacts
         run: cd packages/pack && npm run artifacts
@@ -331,6 +356,7 @@ jobs:
           npm version --workspace=@utoo/pack-cli "${VERSION}" --no-git-tag-version --workspaces-update=false &&
           npm pkg set dependencies.@utoo/pack-shared="${VERSION}" --workspace=@utoo/pack &&
           npm pkg set dependencies.@utoo/pack="${VERSION}" --workspace=@utoo/pack-cli &&
+          npm run check:binding-version --workspace=@utoo/pack -- "${VERSION}" &&
           npm publish --workspace=@utoo/pack-shared --access public --tag "${TAG}" &&
           npm publish --workspace=@utoo/pack --access public --tag "${TAG}" &&
           npm publish --workspace=@utoo/pack-cli --access public --tag "${TAG}"

--- a/packages/pack/package.json
+++ b/packages/pack/package.json
@@ -83,6 +83,7 @@
     "artifacts": "napi artifacts --output-dir ./src --npm-dir npm",
     "build:binding": "napi build --platform --release -p pack-napi --manifest-path ../../Cargo.toml -o src --features plugin --js binding.js --dts binding.d.ts",
     "build:binding:local": "napi build --platform --profile release-local -p pack-napi --manifest-path ../../Cargo.toml -o src --features plugin --js binding.js --dts binding.d.ts",
+    "check:binding-version": "node scripts/check-binding-version.cjs",
     "test": "vitest run",
     "clean": "rm -rf cjs esm",
     "prepublishOnly": "npm run build:js && napi pre-publish -t npm --no-gh-release",

--- a/packages/pack/scripts/check-binding-version.cjs
+++ b/packages/pack/scripts/check-binding-version.cjs
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+
+const packageJson = require("../package.json");
+const expectedVersion = process.argv[2] ?? packageJson.version;
+const bindingPath = path.join(__dirname, "../src/binding.js");
+const bindingSource = fs.readFileSync(bindingPath, "utf8");
+const versions = [
+  ...bindingSource.matchAll(/bindingPackageVersion !== ["']([^"']+)["']/g),
+].map((match) => match[1]);
+
+if (versions.length === 0) {
+  throw new Error(`No native binding package version checks found in ${bindingPath}`);
+}
+
+const mismatchedVersions = [...new Set(versions.filter((version) => version !== expectedVersion))];
+
+if (mismatchedVersions.length > 0) {
+  throw new Error(
+    `Expected ${expectedVersion} in ${bindingPath}, found ${mismatchedVersions.join(", ")}`,
+  );
+}
+
+console.log(`Verified ${versions.length} native binding version checks for ${expectedVersion}`);


### PR DESCRIPTION
## Summary

- Resolve the NAPI binding package version from the release tag before native builds start.
- Pass that version through every host and container build so NAPI CLI v3 generates a matching `binding.js`.
- Publish the generated loader as its own artifact and validate all embedded native package version checks before npm publishing.

Without this, release tags update `package.json` only in the publish job while the generated loader keeps the repository version, causing strict NAPI version checks to reject otherwise matching platform packages.

## Test Plan

- Generated `binding.js` with `npm_new_version=9.9.9` using `@napi-rs/cli@3.8.6` and verified all 27 embedded checks use `9.9.9`.
- Restored the repository version and ran `npm run check:binding-version --workspace=@utoo/pack`.
- Confirmed the checker rejects a mismatched expected version.
- `cargo build --features plugin -p pack-napi --profile release-local`
- `npx biome check packages/pack/package.json packages/pack/scripts/check-binding-version.cjs`
- Parsed `.github/workflows/pack-release.yml` as YAML.
