### PR TITLE
ci(pack): validate NAPI targets and Node 20

### DIFF
--- a/.github/workflows/pack-ci.yml
+++ b/.github/workflows/pack-ci.yml
@@ -23,10 +23,12 @@ jobs:
           - host: macos-latest
             target: aarch64-apple-darwin
             test: |
+              cargo check -p pack-napi --features plugin --target aarch64-apple-darwin &&
               cargo test -p pack-tests --target aarch64-apple-darwin
           - host: macos-latest
             target: x86_64-apple-darwin
             test: |
+              cargo check -p pack-napi --features plugin --target x86_64-apple-darwin &&
               cargo test -p pack-tests --target x86_64-apple-darwin
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -36,6 +38,7 @@ jobs:
               rustup install nightly-2026-07-29 &&
               rustup default nightly-2026-07-29 &&
               rustup target add x86_64-unknown-linux-gnu &&
+              cargo check -p pack-napi --features plugin --target x86_64-unknown-linux-gnu &&
               cargo test -p pack-tests --target x86_64-unknown-linux-gnu
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
@@ -51,6 +54,7 @@ jobs:
               rustup default nightly-2026-07-29 &&
               rustup target add x86_64-unknown-linux-musl &&
               export RUSTFLAGS='--cfg tokio_unstable -Zshare-generics=y -Zthreads=8 -Csymbol-mangling-version=v0 -Ctarget-feature=-crt-static' &&
+              cargo check -p pack-napi --features plugin --target x86_64-unknown-linux-musl &&
               cargo test -p pack-tests --target x86_64-unknown-linux-musl
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
@@ -61,6 +65,7 @@ jobs:
               rustup default nightly-2026-07-29 &&
               rustup target add aarch64-unknown-linux-gnu &&
               export QEMU_LD_PREFIX=/usr/aarch64-linux-gnu &&
+              cargo check -p pack-napi --features plugin --target aarch64-unknown-linux-gnu &&
               cargo test -p pack-tests --target aarch64-unknown-linux-gnu
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
@@ -76,6 +81,7 @@ jobs:
               rustup default nightly-2026-07-29 &&
               rustup target add aarch64-unknown-linux-musl &&
               export RUSTFLAGS='--cfg tokio_unstable -Zshare-generics=y -Zthreads=8 -Csymbol-mangling-version=v0' &&
+              cargo check -p pack-napi --features plugin --target aarch64-unknown-linux-musl &&
               cargo test -p pack-tests --target aarch64-unknown-linux-musl
           # swc_plugin_runner not supported on aarch64 windows now
           # - host: windows-latest

--- a/.github/workflows/pack-integration.yml
+++ b/.github/workflows/pack-integration.yml
@@ -42,13 +42,27 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.14.0
+          node-version: 20
 
       - name: Setup Utoo
         uses: utooland/setup-utoo@v1
 
+      - name: Keep Node 20 for integration tests
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json'));
+            delete pkg.engines['install-node'];
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
       - name: Install dependencies
         run: utoo install
+
+      - name: Verify Node 20 runtime
+        run: |
+          test "$(node -p 'process.versions.node.split(".")[0]')" = "20"
+          test "$(npm exec -- node -p 'process.versions.node.split(".")[0]')" = "20"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@master
@@ -65,6 +79,9 @@ jobs:
           npm run build --workspace @utoo/pack-shared
           npm run build:local --workspace @utoo/pack
           npm run build --workspace @utoo/pack-cli
+
+          # Exercise the generated NAPI loader on the minimum supported Node major.
+          NAPI_RS_ENFORCE_VERSION_CHECK=1 node -e 'require("./packages/pack/src/binding.js")'
 
           # Regression coverage for independent PostCSS and loader evaluator graphs sharing one
           # build-time runtime (utooland/utoo#3316).


### PR DESCRIPTION
## Summary

- Compile `pack-napi` with the `plugin` feature for every currently supported macOS and Linux target in the Pack CI matrix.
- Run the existing full Pack integration workflow on Node 20, the lowest supported Node major, while release builds continue to cover Node 22.
- Remove the root `engines.install-node` override before dependency installation and assert that both direct and npm-resolved commands use Node 20.
- Add an explicit Node 20 smoke test for the generated NAPI loader.

The existing snapshot matrix compiled `pack-tests`, but that crate does not enable the NAPI binding's `plugin` feature chain. The integration workflow also only exercised Node 22 despite the published packages declaring Node 20 support.

## Test Plan

- `cargo check -p pack-napi --features plugin --target aarch64-apple-darwin`
- `cargo check -p pack-napi --features plugin --target x86_64-apple-darwin`
- Loaded `packages/pack/src/binding.js` successfully on Node 20.19.1 with `NAPI_RS_ENFORCE_VERSION_CHECK=1`.
- Verified Node 20 through both direct `node` and `npm exec -- node` resolution.
- Parsed `.github/workflows/pack-ci.yml` and `.github/workflows/pack-integration.yml` as YAML.
