### PR TITLE
feat(pack): show task progress in build and dev

### DIFF
--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -985,6 +985,16 @@ impl From<UpdateInfo> for NapiUpdateInfo {
     }
 }
 
+#[napi]
+pub fn project_get_completed_task_count(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
+) -> u32 {
+    project
+        .turbopack_ctx
+        .turbo_tasks()
+        .get_completed_scheduled_task_count() as u32
+}
+
 /// Subscribes to lifecycle events of the compilation.
 ///
 /// Emits an [UpdateMessage::Start] event when any computation starts.

--- a/crates/pack-napi/src/pack_api/project.rs
+++ b/crates/pack-napi/src/pack_api/project.rs
@@ -129,7 +129,8 @@ pub struct NapiProjectOptions {
     /// The build id.
     pub build_id: String,
 
-    /// Whether to enable default tracing logs.
+    /// Whether the JavaScript caller emits compilation progress. Rust tracing is configured with
+    /// `RUST_LOG`.
     pub tracing: bool,
 
     pub pack_path: String,
@@ -472,20 +473,12 @@ pub fn project_new<'env>(
                 .with(chrome_layer)
                 .init();
         });
-    } else if options.tracing {
+    } else if let Ok(env_filter) = EnvFilter::try_from_default_env() {
         TRACING_INIT.call_once(|| {
-            let env_filter = EnvFilter::try_from_default_env();
-            let env_filter_enabled = env_filter.is_ok();
             tracing_subscriber::fmt()
-                .with_env_filter(env_filter.unwrap_or_else(|_| {
-                    EnvFilter::new("pack_napi=info,pack_api=info,pack_core=info")
-                }))
-                .with_target(env_filter_enabled)
-                .with_span_events(if env_filter_enabled {
-                    FmtSpan::CLOSE
-                } else {
-                    FmtSpan::NONE
-                })
+                .with_env_filter(env_filter)
+                .with_target(true)
+                .with_span_events(FmtSpan::CLOSE)
                 .with_timer(tracing_subscriber::fmt::time::ChronoLocal::new(
                     "%Y-%m-%d %H:%M:%S.%3f".to_string(),
                 ))

--- a/packages/pack-cli/src/commands/build.ts
+++ b/packages/pack-cli/src/commands/build.ts
@@ -24,7 +24,7 @@ export default defineCommand({
     },
     tracing: {
       type: "boolean",
-      description: "Enable default tracing logs (pass --no-tracing to disable)",
+      description: "Show compilation progress (pass --no-tracing to disable)",
     },
   },
   async run({ args }) {

--- a/packages/pack-cli/src/commands/dev.ts
+++ b/packages/pack-cli/src/commands/dev.ts
@@ -24,7 +24,7 @@ export default defineCommand({
     },
     tracing: {
       type: "boolean",
-      description: "Enable default tracing logs (pass --no-tracing to disable)",
+      description: "Show compilation progress (pass --no-tracing to disable)",
     },
   },
   async run({ args }) {

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -502,8 +502,8 @@ export interface BundleOptions {
   buildId?: string;
 
   /**
-   * Whether to enable default utoopack tracing logs.
-   * Defaults to true.
+   * Whether to show utoopack compilation progress.
+   * Defaults to true. Rust tracing logs are controlled by `RUST_LOG`.
    */
   tracing?: boolean;
 

--- a/packages/pack/src/__test__/browserLogsHmr.test.ts
+++ b/packages/pack/src/__test__/browserLogsHmr.test.ts
@@ -18,6 +18,7 @@ const projectMocks = vi.hoisted(() => {
     shutdown: vi.fn(async () => {}),
     traceSource: vi.fn(async () => null),
     updateInfoSubscribe: () => (async function* () {})(),
+    getCompletedTaskCount: vi.fn(() => 0),
   };
 
   return {

--- a/packages/pack/src/__test__/hmrClientIsolation.test.ts
+++ b/packages/pack/src/__test__/hmrClientIsolation.test.ts
@@ -22,6 +22,7 @@ const projectMocks = vi.hoisted(() => {
     onExit: vi.fn(async () => {}),
     shutdown: vi.fn(async () => {}),
     updateInfoSubscribe: () => (async function* () {})(),
+    getCompletedTaskCount: vi.fn(() => 0),
   };
 
   return {

--- a/packages/pack/src/__test__/serveClientPathsChild.ts
+++ b/packages/pack/src/__test__/serveClientPathsChild.ts
@@ -13,7 +13,7 @@ const srcDir = path.join(projectPath, "src");
 const statsPath = path.join(projectPath, "dist", "stats.json");
 
 function normalizeFileName(name: string): string {
-  return name.replace(/_[0-9a-f]{8}(?=\.)/g, "_<hash>");
+  return name.replace(/_(?:[0-9a-f]{8}|[0-9a-z_-]{13})(?=\.)/g, "_<hash>");
 }
 
 async function main() {

--- a/packages/pack/src/__test__/serveServerOutputsHmr.test.ts
+++ b/packages/pack/src/__test__/serveServerOutputsHmr.test.ts
@@ -121,7 +121,7 @@ describe("serve server output HMR", () => {
     async (scenario) => {
       await expect(runServerOutputHmrFixture(scenario)).resolves.toEqual({
         initial: "SERVER_OUTPUT_V1",
-        initialCompilingLogs: 0,
+        initialCompilingLogs: 1,
         scenario,
         updated: "SERVER_OUTPUT_V2",
         updateCompilingLogs: 1,

--- a/packages/pack/src/__test__/serveServerOutputsHmrChild.ts
+++ b/packages/pack/src/__test__/serveServerOutputsHmrChild.ts
@@ -12,7 +12,10 @@ let compilingLogCount = 0;
 const originalConsoleLog = console.log;
 
 console.log = (...args: unknown[]) => {
-  if (args[0] === "Compiling...") {
+  if (
+    typeof args[0] === "string" &&
+    /^Compiling\.\.\. \(\d+ tasks? completed\)$/.test(args[0])
+  ) {
     compilingLogCount++;
   }
   originalConsoleLog(...args);

--- a/packages/pack/src/__test__/serveStatsChild.ts
+++ b/packages/pack/src/__test__/serveStatsChild.ts
@@ -14,7 +14,7 @@ const statsPath = path.join(projectPath, "dist", "stats.json");
 const htmlPath = path.join(projectPath, "dist", "index.html");
 
 function normalizeFileName(name: string): string {
-  return name.replace(/_[0-9a-f]{8}(?=\.)/g, "_<hash>");
+  return name.replace(/_(?:[0-9a-f]{8}|[0-9a-z_-]{13})(?=\.)/g, "_<hash>");
 }
 
 function normalizeStats(stats: any) {

--- a/packages/pack/src/__test__/taskProgress.test.ts
+++ b/packages/pack/src/__test__/taskProgress.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  formatDuration,
+  formatTaskCount,
+  TaskProgress,
+} from "../utils/taskProgress";
+
+const originalIsTTY = process.stdout.isTTY;
+
+function setStdoutIsTTY(value: boolean) {
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value,
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  setStdoutIsTTY(originalIsTTY);
+});
+
+describe("TaskProgress", () => {
+  it("logs once outside a TTY and returns the completed task delta", () => {
+    setStdoutIsTTY(false);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    let completed = 10;
+    const progress = new TaskProgress({
+      getCompletedTaskCount: () => completed,
+    });
+
+    progress.start("Compiling");
+    completed = 13;
+
+    expect(progress.stop()).toBe(3);
+    expect(log).toHaveBeenCalledOnce();
+    expect(log).toHaveBeenCalledWith("Compiling... (0 tasks completed)");
+  });
+
+  it("refreshes the completed task count in a TTY", () => {
+    vi.useFakeTimers();
+    setStdoutIsTTY(true);
+    const write = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    let completed = 4;
+    const progress = new TaskProgress({
+      getCompletedTaskCount: () => completed,
+    });
+
+    progress.start("Compiling");
+    completed = 7;
+    vi.advanceTimersByTime(100);
+
+    expect(write.mock.calls.map(([value]) => String(value))).toContain(
+      "\rCompiling... (3 tasks completed)",
+    );
+    expect(progress.stop()).toBe(3);
+  });
+
+  it("handles the u32 counter wrapping", () => {
+    setStdoutIsTTY(false);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    let completed = 0xffff_ffff;
+    const progress = new TaskProgress({
+      getCompletedTaskCount: () => completed,
+    });
+
+    progress.start("Compiling");
+    completed = 1;
+
+    expect(progress.stop()).toBe(2);
+  });
+
+  it("formats durations and task counts", () => {
+    expect(formatDuration(2_000)).toBe("2000ms");
+    expect(formatDuration(2_100)).toBe("2.1s");
+    expect(formatTaskCount(1)).toBe("1 task");
+    expect(formatTaskCount(2)).toBe("2 tasks");
+  });
+});

--- a/packages/pack/src/binding.d.ts
+++ b/packages/pack/src/binding.d.ts
@@ -225,6 +225,8 @@ export interface NapiWrittenEndpoint {
 
 export declare function projectEntrypointsSubscribe(project: { __napiType: "Project" }, func: (err: Error, value: TurbopackResult<NapiEntrypoints>) => void): { __napiType: "RootTask" }
 
+export declare function projectGetCompletedTaskCount(project: { __napiType: "Project" }): number
+
 export declare function projectGetSourceForAsset(project: { __napiType: "Project" }, filePath: string): Promise<string | null>
 
 export declare function projectGetSourceMap(project: { __napiType: "Project" }, filePath: RcStr): Promise<string | null>

--- a/packages/pack/src/binding.d.ts
+++ b/packages/pack/src/binding.d.ts
@@ -131,7 +131,10 @@ export interface NapiProjectOptions {
   dev: boolean
   /** The build id. */
   buildId: string
-  /** Whether to enable default tracing logs. */
+  /**
+   * Whether the JavaScript caller emits compilation progress. Rust tracing is configured with
+   * `RUST_LOG`.
+   */
   tracing: boolean
   packPath: string
 }

--- a/packages/pack/src/binding.js
+++ b/packages/pack/src/binding.js
@@ -710,6 +710,7 @@ module.exports.lockfileUnlock = nativeBinding.lockfileUnlock
 module.exports.lockfileUnlockSync = nativeBinding.lockfileUnlockSync
 module.exports.MemoryEvictionMode = nativeBinding.MemoryEvictionMode
 module.exports.projectEntrypointsSubscribe = nativeBinding.projectEntrypointsSubscribe
+module.exports.projectGetCompletedTaskCount = nativeBinding.projectGetCompletedTaskCount
 module.exports.projectGetSourceForAsset = nativeBinding.projectGetSourceForAsset
 module.exports.projectGetSourceMap = nativeBinding.projectGetSourceMap
 module.exports.projectGetSourceMapSync = nativeBinding.projectGetSourceMapSync

--- a/packages/pack/src/commands/build.ts
+++ b/packages/pack/src/commands/build.ts
@@ -67,6 +67,7 @@ async function buildInternal(
   );
   const shouldCreateWebpackStats =
     Boolean(process.env.ANALYZE) || Boolean(bundleOptions.config.stats);
+  const showProgress = bundleOptions.tracing ?? true;
   processHtmlEntry(bundleOptions.config, resolvedProjectPath);
   validateEntryPaths(bundleOptions.config, resolvedProjectPath);
   await cleanOutput(bundleOptions.config, resolvedProjectPath);
@@ -90,7 +91,7 @@ async function buildInternal(
         },
         dev: bundleOptions.dev ?? false,
         buildId: bundleOptions.buildId || nanoid(),
-        tracing: bundleOptions.tracing ?? true,
+        tracing: showProgress,
         config: {
           ...bundleOptions.config,
           stats: shouldCreateWebpackStats,
@@ -112,20 +113,22 @@ async function buildInternal(
       },
     );
 
-    const progress = new TaskProgress(project);
+    const progress = showProgress ? new TaskProgress(project) : undefined;
     const compileStart = Date.now();
-    progress.start("Compiling");
+    progress?.start("Compiling");
 
     let completedTasks = 0;
     const entrypoints = await project
       .writeAllEntrypointsToDisk()
       .finally(() => {
-        completedTasks = progress.stop();
+        completedTasks = progress?.stop() ?? 0;
       });
 
-    console.log(
-      `Compiled in ${formatDuration(Date.now() - compileStart)} (${formatTaskCount(completedTasks)})`,
-    );
+    if (showProgress) {
+      console.log(
+        `Compiled in ${formatDuration(Date.now() - compileStart)} (${formatTaskCount(completedTasks)})`,
+      );
+    }
 
     handleIssues(entrypoints.issues);
     const htmlGenerationManager = new HtmlGenerationManager(

--- a/packages/pack/src/commands/build.ts
+++ b/packages/pack/src/commands/build.ts
@@ -19,6 +19,11 @@ import { processHtmlEntry } from "../utils/htmlEntry";
 import { acquirePersistentCacheLock } from "../utils/lockfile";
 import { normalizePath } from "../utils/normalizePath";
 import { useWorkerThreads } from "../utils/runtimePluginStratety";
+import {
+  formatDuration,
+  formatTaskCount,
+  TaskProgress,
+} from "../utils/taskProgress";
 import { validateEntryPaths } from "../utils/validateEntry";
 import { xcodeProfilingReady } from "../utils/xcodeProfile";
 
@@ -107,7 +112,20 @@ async function buildInternal(
       },
     );
 
-    const entrypoints = await project.writeAllEntrypointsToDisk();
+    const progress = new TaskProgress(project);
+    const compileStart = Date.now();
+    progress.start("Compiling");
+
+    let completedTasks = 0;
+    const entrypoints = await project
+      .writeAllEntrypointsToDisk()
+      .finally(() => {
+        completedTasks = progress.stop();
+      });
+
+    console.log(
+      `Compiled in ${formatDuration(Date.now() - compileStart)} (${formatTaskCount(completedTasks)})`,
+    );
 
     handleIssues(entrypoints.issues);
     const htmlGenerationManager = new HtmlGenerationManager(

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -273,6 +273,7 @@ export async function createHotReloader(
   );
   const shouldCreateWebpackStats =
     Boolean(process.env.ANALYZE) || Boolean(bundleOptions.config.stats);
+  const showProgress = bundleOptions.tracing ?? true;
 
   let project: Project;
   try {
@@ -285,7 +286,7 @@ export async function createHotReloader(
         },
         dev: true,
         buildId: bundleOptions.buildId || nanoid(),
-        tracing: bundleOptions.tracing ?? true,
+        tracing: showProgress,
         config: {
           ...bundleOptions.config,
           mode: "development",
@@ -315,7 +316,7 @@ export async function createHotReloader(
     throw error;
   }
 
-  const progress = new TaskProgress(project);
+  const progress = showProgress ? new TaskProgress(project) : undefined;
 
   const entrypointsSubscription = project.entrypointsSubscribe();
 
@@ -343,19 +344,20 @@ export async function createHotReloader(
   let closePromise: Promise<void> | undefined;
 
   function markHmrEvent() {
-    if (!hmrEventHappened) {
-      progress.start("Compiling");
-      hmrEventHappened = true;
-    }
-  }
-
-  function finishHmrEvent(duration: number) {
-    const completedTasks = progress.stop();
-
-    if (!hmrEventHappened) {
+    if (!progress || hmrEventHappened) {
       return;
     }
 
+    progress.start("Compiling");
+    hmrEventHappened = true;
+  }
+
+  function finishHmrEvent(duration: number) {
+    if (!progress || !hmrEventHappened) {
+      return;
+    }
+
+    const completedTasks = progress.stop();
     console.log(
       `Compiled in ${formatDuration(duration)} (${formatTaskCount(completedTasks)})`,
     );
@@ -942,7 +944,7 @@ export async function createHotReloader(
 
     async close() {
       hmrEventHappened = false;
-      progress.stop();
+      progress?.stop();
       closed = true;
       const disposePromise = disposeBackgroundWatchSubscriptions();
       closePromise ??= (

--- a/packages/pack/src/core/hmr.ts
+++ b/packages/pack/src/core/hmr.ts
@@ -28,6 +28,11 @@ import { acquirePersistentCacheLock } from "../utils/lockfile";
 import { normalizePath } from "../utils/normalizePath";
 import { useWorkerThreads } from "../utils/runtimePluginStratety";
 import { isNodeTarget } from "../utils/target";
+import {
+  formatDuration,
+  formatTaskCount,
+  TaskProgress,
+} from "../utils/taskProgress";
 import { validateEntryPaths } from "../utils/validateEntry";
 import { forwardBrowserLogs, isBrowserLogsMessage } from "./browserLogs";
 import { consumeHmrSubscription } from "./hmrSubscription";
@@ -310,6 +315,8 @@ export async function createHotReloader(
     throw error;
   }
 
+  const progress = new TaskProgress(project);
+
   const entrypointsSubscription = project.entrypointsSubscribe();
 
   let currentEntriesHandlingResolve: ((value?: unknown) => void) | undefined;
@@ -337,9 +344,22 @@ export async function createHotReloader(
 
   function markHmrEvent() {
     if (!hmrEventHappened) {
-      console.log("Compiling...");
+      progress.start("Compiling");
       hmrEventHappened = true;
     }
+  }
+
+  function finishHmrEvent(duration: number) {
+    const completedTasks = progress.stop();
+
+    if (!hmrEventHappened) {
+      return;
+    }
+
+    console.log(
+      `Compiled in ${formatDuration(duration)} (${formatTaskCount(completedTasks)})`,
+    );
+    hmrEventHappened = false;
   }
 
   function sendToClient(client: WSLike, payload: HMR_ACTION_TYPES) {
@@ -921,6 +941,8 @@ export async function createHotReloader(
     },
 
     async close() {
+      hmrEventHappened = false;
+      progress.stop();
       closed = true;
       const disposePromise = disposeBackgroundWatchSubscriptions();
       closePromise ??= (
@@ -942,6 +964,9 @@ export async function createHotReloader(
     },
   };
 
+  const initialBuildStart = Date.now();
+  markHmrEvent();
+
   handleEntrypointsSubscription().catch((err) => {
     console.error(err);
     process.exit(1);
@@ -949,6 +974,8 @@ export async function createHotReloader(
 
   // Write empty manifests
   await currentEntriesHandling;
+
+  finishHmrEvent(Date.now() - initialBuildStart);
 
   async function handleProjectUpdates() {
     for await (const updateMessage of project.updateInfoSubscribe(30)) {
@@ -980,13 +1007,7 @@ export async function createHotReloader(
             });
           }
 
-          if (hmrEventHappened) {
-            const time = updateMessage.value!.duration;
-            const timeMessage =
-              time > 2000 ? `${Math.round(time / 100) / 10}s` : `${time}ms`;
-            console.log(`Compiled in ${timeMessage}`);
-            hmrEventHappened = false;
-          }
+          finishHmrEvent(updateMessage.value!.duration);
           break;
         }
         default:

--- a/packages/pack/src/core/project.ts
+++ b/packages/pack/src/core/project.ts
@@ -598,6 +598,10 @@ export function projectFactory(endpointWatchOptions?: {
       return binding.projectGetSourceMapSync(this._nativeProject, filePath);
     }
 
+    getCompletedTaskCount(): number {
+      return binding.projectGetCompletedTaskCount(this._nativeProject);
+    }
+
     updateInfoSubscribe(aggregationMs: number) {
       return subscribe<NapiUpdateMessage>(true, async (callback) =>
         binding.projectUpdateInfoSubscribe(

--- a/packages/pack/src/core/types.ts
+++ b/packages/pack/src/core/types.ts
@@ -85,6 +85,8 @@ export interface Project {
     currentDirectoryFileUrl: string,
   ): Promise<StackFrame | null>;
 
+  getCompletedTaskCount(): number;
+
   updateInfoSubscribe(
     aggregationMs: number,
   ): AsyncIterableIterator<NapiUpdateMessage>;

--- a/packages/pack/src/utils/taskProgress.ts
+++ b/packages/pack/src/utils/taskProgress.ts
@@ -1,0 +1,82 @@
+import type { Project } from "../core/types";
+
+const UPDATE_INTERVAL_MS = 100;
+
+export class TaskProgress {
+  private baseline: number;
+  private label: string | undefined;
+  private timer: NodeJS.Timeout | undefined;
+  private lastCompleted = -1;
+  private lastLineLength = 0;
+
+  constructor(
+    private readonly project: Pick<Project, "getCompletedTaskCount">,
+  ) {
+    this.baseline = project.getCompletedTaskCount();
+  }
+
+  start(label: string): void {
+    this.label = label;
+    this.lastCompleted = -1;
+    this.render();
+
+    if (process.stdout.isTTY) {
+      this.timer = setInterval(() => this.render(), UPDATE_INTERVAL_MS);
+      this.timer.unref();
+    }
+  }
+
+  stop(): number {
+    const current = this.project.getCompletedTaskCount();
+    const completed = (current - this.baseline) >>> 0;
+
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+
+    if (this.label && process.stdout.isTTY) {
+      process.stdout.write(`\r${" ".repeat(this.lastLineLength)}\r`);
+    }
+
+    this.label = undefined;
+    this.lastCompleted = -1;
+    this.lastLineLength = 0;
+    this.baseline = current;
+
+    return completed;
+  }
+
+  private render(): void {
+    if (!this.label) {
+      return;
+    }
+
+    const current = this.project.getCompletedTaskCount();
+    const completed = (current - this.baseline) >>> 0;
+
+    if (completed === this.lastCompleted) {
+      return;
+    }
+
+    this.lastCompleted = completed;
+    const message = `${this.label}... (${formatTaskCount(completed)} completed)`;
+
+    if (process.stdout.isTTY) {
+      process.stdout.write(`\r${message.padEnd(this.lastLineLength, " ")}`);
+      this.lastLineLength = message.length;
+    } else {
+      console.log(message);
+    }
+  }
+}
+
+export function formatDuration(durationMs: number): string {
+  return durationMs > 2_000
+    ? `${Math.round(durationMs / 100) / 10}s`
+    : `${durationMs}ms`;
+}
+
+export function formatTaskCount(taskCount: number): string {
+  return `${taskCount} ${taskCount === 1 ? "task" : "tasks"}`;
+}


### PR DESCRIPTION
## Summary

- Add live completed-task progress output for utoopack build, initial dev compilation, and subsequent HMR compilations.
- Expose the cumulative TurboTasks completed-task counter through NAPI and the Pack Project API, using the capability merged in utooland/next.js#187.
- Refresh TTY output every 100ms, keep non-TTY output stable, and print the completed task total with the final compile duration.
- Make the existing `tracing` option and `--no-tracing` CLI flag control compilation progress output.
- Disable Rust fmt tracing by default and initialize it only when `RUST_LOG` contains a valid filter, while preserving explicit Turbopack and Chrome performance tracing.
- Update test hash normalization for the latest 13-character base38 Turbopack chunk identifiers.

## Test Plan

- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings --no-deps`
- `npx biome ci`
- `npx tombi format --check`
- `typos`
- `npx tsc --noEmit -p packages/pack/tsconfig.json`
- `npx tsc --noEmit -p packages/pack-cli/tsconfig.json --incremental false`
- `npm run build:binding:local --workspace @utoo/pack`
- `npm test --workspace @utoo/pack`: 89 tests passed
- `ut build:local` in `packages/utoo-web`
- Default build in `examples/multi-entries-heavy`: compilation progress is shown without Rust INFO logs
- Build with `--no-tracing`: compilation progress is suppressed
- Build with `RUST_LOG=pack_napi=info,pack_api=info,pack_core=info`: compilation progress and Rust INFO logs are both shown
- Build with `--no-tracing` and `RUST_LOG=pack_napi=info,pack_api=info,pack_core=info`: only Rust INFO logs are shown
- Dev in `examples/multi-entries-heavy`: default mode shows live task progress, `--no-tracing` suppresses it, and both modes start and stop cleanly

Closes #2327
