### PR TITLE
feat(pm): support pnpm-style publishConfig manifest overrides

### DIFF
--- a/crates/pm/src/service/pm_pack.rs
+++ b/crates/pm/src/service/pm_pack.rs
@@ -25,9 +25,8 @@ pub struct PackResult {
     pub integrity: String,
     pub unpacked_size: u64,
     pub packed_size: u64,
-    /// The manifest as written into the tarball — with `workspace:`/`catalog:`
-    /// specifiers rewritten to concrete versions. Reused to build the publish
-    /// payload so the registry metadata matches the packed `package.json`.
+    /// The normalized manifest as written into the tarball. Reused to build the
+    /// publish payload so registry metadata matches the packed `package.json`.
     pub manifest: PackageJson,
 }
 
@@ -58,17 +57,20 @@ pub async fn pack(package_root: &Path, output: ScriptOutput) -> Result<PackResul
     // is cached from before the script ran, so read the current file from disk.
     let pkg: PackageJson = load_package_json(package_root).await?;
 
-    // Rewrite `workspace:`/`catalog:` specifiers so the packed manifest is
-    // installable outside the workspace. `None` means there was nothing to
-    // rewrite, in which case the on-disk package.json is packed verbatim.
+    // Normalize dependency protocols and publish-time manifest overrides.
+    // `None` means there was nothing to rewrite, in which case the on-disk
+    // package.json is packed verbatim.
     let normalized = normalize_publish_manifest(package_root, &pkg).await?;
     let pkg_json_override = normalized.as_ref().map(serialize_manifest).transpose()?;
+    let packed_manifest = normalized.unwrap_or_else(|| pkg.clone());
 
     // collect_pack_files uses ignore::WalkBuilder which does synchronous I/O.
     // Run on a blocking thread to avoid stalling the tokio runtime.
     let package_root_owned = package_root.to_path_buf();
     let collected = tokio::task::spawn_blocking({
-        let data = pkg.to_value();
+        // Publish-time main/types/bin overrides affect npm's always-included
+        // referenced files, so file selection must use the packed manifest.
+        let data = packed_manifest.to_value();
         let package_root = package_root_owned.clone();
         move || collect_pack_files(&package_root, &data)
     })
@@ -102,18 +104,18 @@ pub async fn pack(package_root: &Path, output: ScriptOutput) -> Result<PackResul
     Ok(PackResult {
         tarball_data: tar_data,
         files: file_paths,
-        name: package_info.name,
-        version: pkg.version.clone(),
+        name: packed_manifest.name.clone(),
+        version: packed_manifest.version.clone(),
         integrity,
         unpacked_size,
         packed_size,
-        manifest: normalized.unwrap_or(pkg),
+        manifest: packed_manifest,
     })
 }
 
 /// Whether `path` is the root-level `package.json` (the only manifest the
-/// `workspace:`/`catalog:` rewrite substitutes — nested `package.json` files
-/// are packed verbatim).
+/// publish normalization substitutes — nested `package.json` files are packed
+/// verbatim).
 fn is_root_manifest(path: &Path) -> bool {
     path == Path::new("package.json")
 }

--- a/crates/pm/src/service/pm_pack.rs
+++ b/crates/pm/src/service/pm_pack.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use ignore::WalkBuilder;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use std::fs;
 use std::io::{ErrorKind, Write};
 use std::path::{Component, Path, PathBuf};
@@ -193,6 +194,7 @@ fn create_tarball(
     let mut encoder = GzEncoder::new(Vec::with_capacity(raw_estimate / 2), Compression::default());
     {
         let mut builder = Builder::new(&mut encoder);
+        builder.follow_symlinks(false);
         for (file_path, _) in files {
             let archive_path = Path::new("package").join(file_path);
             // Substitute the rewritten manifest for the on-disk package.json.
@@ -266,6 +268,12 @@ fn collect_pack_files(
 ) -> Result<Vec<(PathBuf, u64)>> {
     let whitelist = compile_whitelist(package_json);
     let referenced_files = collect_referenced_files(package_json);
+    let mandatory_references = collect_mandatory_references(package_json);
+    let root_ignore = if whitelist.is_none() {
+        load_root_ignore(package_root)?
+    } else {
+        None
+    };
     let builder = build_file_walker(package_root, whitelist.is_some());
 
     let mut files = Vec::new();
@@ -293,11 +301,16 @@ fn collect_pack_files(
         }
     }
 
-    // Root ignore files can prune a referenced file's parent directory before
-    // the inclusion check sees it. Re-check exact manifest references without
-    // following symlinks so main/browser/types/bin remain mandatory but cannot
-    // escape the package root.
-    add_missing_referenced_files(package_root, &referenced_files, &mut files)?;
+    // Root ignore files can prune an entry point's parent directory before the
+    // inclusion check sees it. Re-check only clean, exact main/browser/bin
+    // references. Utoo deliberately does not emulate npm-packlist's ambiguous
+    // slash and nested-ignore edge cases here.
+    add_missing_referenced_files(
+        package_root,
+        root_ignore.as_ref(),
+        &mandatory_references,
+        &mut files,
+    )?;
 
     files.sort_by(|(a, _), (b, _)| a.cmp(b));
     Ok(files)
@@ -305,9 +318,15 @@ fn collect_pack_files(
 
 fn add_missing_referenced_files(
     package_root: &Path,
+    root_ignore: Option<&Gitignore>,
     referenced_files: &std::collections::HashSet<String>,
     files: &mut Vec<(PathBuf, u64)>,
 ) -> Result<()> {
+    let Some(root_ignore) = root_ignore else {
+        return Ok(());
+    };
+    let canonical_root = fs::canonicalize(package_root)
+        .with_context(|| format!("Failed to resolve {}", package_root.display()))?;
     let mut collected: std::collections::HashSet<PathBuf> =
         files.iter().map(|(path, _)| path.clone()).collect();
     for referenced in referenced_files {
@@ -315,12 +334,18 @@ fn add_missing_referenced_files(
             continue;
         }
         let relative = PathBuf::from(referenced);
+        if !root_ignore_prunes_reference(package_root, root_ignore, &relative) {
+            continue;
+        }
         if collected.contains(&relative) || !is_safe_referenced_path(&relative) {
             continue;
         }
-        if let Some(size) = referenced_file_size(package_root, &relative)? {
-            collected.insert(relative.clone());
-            files.push((relative, size));
+        if let Some((actual_relative, size)) =
+            resolve_referenced_file(package_root, &canonical_root, &relative)?
+            && !contains_collected_path(&collected, &actual_relative)
+        {
+            collected.insert(actual_relative.clone());
+            files.push((actual_relative, size));
         }
     }
     Ok(())
@@ -335,7 +360,7 @@ fn is_safe_referenced_path(path: &Path) -> bool {
         };
         has_component = true;
         let name = name.to_string_lossy();
-        if components.peek().is_some() && ALWAYS_EXCLUDE_DIRS.contains(&name.as_ref()) {
+        if components.peek().is_some() && is_excluded_directory(&name) {
             return false;
         }
     }
@@ -345,10 +370,14 @@ fn is_safe_referenced_path(path: &Path) -> bool {
             .is_some_and(|name| !is_excluded_file(&name.to_string_lossy()))
 }
 
-fn referenced_file_size(package_root: &Path, relative: &Path) -> Result<Option<u64>> {
+fn resolve_referenced_file(
+    package_root: &Path,
+    canonical_root: &Path,
+    relative: &Path,
+) -> Result<Option<(PathBuf, u64)>> {
     let components: Vec<_> = relative.components().collect();
     let mut current = package_root.to_path_buf();
-    for (index, component) in components.iter().enumerate() {
+    for component in &components {
         current.push(component.as_os_str());
         let metadata = match fs::symlink_metadata(&current) {
             Ok(metadata) => metadata,
@@ -361,15 +390,80 @@ fn referenced_file_size(package_root: &Path, relative: &Path) -> Result<Option<u
         if metadata.file_type().is_symlink() {
             return Ok(None);
         }
-        let is_last = index + 1 == components.len();
-        if is_last {
-            return Ok(metadata.is_file().then_some(metadata.len()));
-        }
-        if !metadata.is_dir() {
+        if current != package_root.join(relative) && !metadata.is_dir() {
             return Ok(None);
         }
     }
-    Ok(None)
+    let canonical_file = fs::canonicalize(&current)
+        .with_context(|| format!("Failed to resolve {}", current.display()))?;
+    let Ok(actual_relative) = canonical_file.strip_prefix(canonical_root) else {
+        return Ok(None);
+    };
+    if !is_safe_referenced_path(actual_relative) {
+        return Ok(None);
+    }
+    let metadata = fs::metadata(&canonical_file)
+        .with_context(|| format!("Failed to inspect {}", canonical_file.display()))?;
+    Ok(metadata
+        .is_file()
+        .then_some((actual_relative.to_path_buf(), metadata.len())))
+}
+
+fn contains_collected_path(collected: &std::collections::HashSet<PathBuf>, path: &Path) -> bool {
+    if cfg!(any(target_os = "macos", windows)) {
+        let path = path.to_string_lossy();
+        collected
+            .iter()
+            .any(|item| item.to_string_lossy().eq_ignore_ascii_case(&path))
+    } else {
+        collected.contains(path)
+    }
+}
+
+fn root_ignore_prunes_reference(
+    package_root: &Path,
+    root_ignore: &Gitignore,
+    relative: &Path,
+) -> bool {
+    if root_ignore
+        .matched_path_or_any_parents(package_root.join(relative), false)
+        .is_ignore()
+    {
+        return true;
+    }
+    let Some(parent) = relative.parent() else {
+        return false;
+    };
+    let mut current = PathBuf::new();
+    for component in parent.components() {
+        current.push(component.as_os_str());
+        if root_ignore
+            .matched(package_root.join(&current), true)
+            .is_ignore()
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn load_root_ignore(package_root: &Path) -> Result<Option<Gitignore>> {
+    let npmignore = package_root.join(".npmignore");
+    let ignore_file = if npmignore.exists() {
+        npmignore
+    } else {
+        let gitignore = package_root.join(".gitignore");
+        if !gitignore.exists() {
+            return Ok(None);
+        }
+        gitignore
+    };
+    let mut builder = GitignoreBuilder::new(package_root);
+    builder.case_insensitive(cfg!(any(target_os = "macos", windows)))?;
+    if let Some(error) = builder.add(ignore_file) {
+        return Err(error.into());
+    }
+    Ok(Some(builder.build()?))
 }
 
 fn compile_whitelist(
@@ -411,6 +505,49 @@ fn collect_referenced_files(pkg: &serde_json::Value) -> std::collections::HashSe
     refs
 }
 
+fn collect_mandatory_references(pkg: &serde_json::Value) -> std::collections::HashSet<String> {
+    let mut refs = std::collections::HashSet::new();
+    for key in ["main", "browser"] {
+        if let Some(reference) = pkg.get(key).and_then(|value| value.as_str())
+            && let Some(reference) = clean_package_file_reference(reference)
+        {
+            refs.insert(reference);
+        }
+    }
+    if let Some(bin) = pkg.get("bin") {
+        match bin {
+            serde_json::Value::String(reference) => {
+                if let Some(reference) = clean_package_file_reference(reference) {
+                    refs.insert(reference);
+                }
+            }
+            serde_json::Value::Object(map) => {
+                refs.extend(
+                    map.values()
+                        .filter_map(|value| value.as_str())
+                        .filter_map(clean_package_file_reference),
+                );
+            }
+            _ => {}
+        }
+    }
+    refs
+}
+
+fn clean_package_file_reference(reference: &str) -> Option<String> {
+    let normalized = reference.replace('\\', "/");
+    let relative = normalized.strip_prefix("./").unwrap_or(&normalized);
+    if relative.is_empty() || relative.starts_with('/') || relative.ends_with('/') {
+        return None;
+    }
+    if relative.split('/').any(|component| {
+        component.is_empty() || component == "." || component == ".." || component.contains(':')
+    }) {
+        return None;
+    }
+    Some(relative.to_string())
+}
+
 fn build_file_walker(package_root: &Path, has_whitelist: bool) -> WalkBuilder {
     let has_npmignore = package_root.join(".npmignore").exists();
     let mut builder = WalkBuilder::new(package_root);
@@ -419,7 +556,8 @@ fn build_file_walker(package_root: &Path, has_whitelist: bool) -> WalkBuilder {
         .ignore(false)
         .git_global(false)
         .git_exclude(false)
-        .git_ignore(false);
+        .git_ignore(false)
+        .ignore_case_insensitive(cfg!(any(target_os = "macos", windows)));
 
     if has_whitelist {
         // Whitelist mode: no ignore files
@@ -432,7 +570,7 @@ fn build_file_walker(package_root: &Path, has_whitelist: bool) -> WalkBuilder {
     builder.filter_entry(|entry| {
         if entry.file_type().is_some_and(|ft| ft.is_dir()) {
             let name = entry.file_name().to_string_lossy();
-            return !ALWAYS_EXCLUDE_DIRS.contains(&name.as_ref());
+            return !is_excluded_directory(&name);
         }
         true
     });
@@ -476,9 +614,39 @@ fn is_always_included(lower_rel_path: &str) -> bool {
 }
 
 fn is_excluded_file(name: &str) -> bool {
-    ALWAYS_EXCLUDE_FILES.contains(&name)
-        || ALWAYS_EXCLUDE_PREFIXES.iter().any(|p| name.starts_with(p))
-        || ALWAYS_EXCLUDE_SUFFIXES.iter().any(|s| name.ends_with(s))
+    ALWAYS_EXCLUDE_FILES
+        .iter()
+        .any(|excluded| hard_name_eq(name, excluded))
+        || ALWAYS_EXCLUDE_PREFIXES
+            .iter()
+            .any(|prefix| hard_name_starts_with(name, prefix))
+        || ALWAYS_EXCLUDE_SUFFIXES
+            .iter()
+            .any(|suffix| hard_name_ends_with(name, suffix))
+}
+
+fn is_excluded_directory(name: &str) -> bool {
+    ALWAYS_EXCLUDE_DIRS
+        .iter()
+        .any(|excluded| hard_name_eq(name, excluded))
+}
+
+fn hard_name_eq(name: &str, expected: &str) -> bool {
+    if cfg!(any(target_os = "macos", windows)) {
+        name.eq_ignore_ascii_case(expected)
+    } else {
+        name == expected
+    }
+}
+
+fn hard_name_starts_with(name: &str, prefix: &str) -> bool {
+    name.get(..prefix.len())
+        .is_some_and(|start| hard_name_eq(start, prefix))
+}
+
+fn hard_name_ends_with(name: &str, suffix: &str) -> bool {
+    name.get(name.len().saturating_sub(suffix.len())..)
+        .is_some_and(|end| hard_name_eq(end, suffix))
 }
 
 fn matches_any(path: &str, compiled: &[(String, Option<globset::GlobMatcher>)]) -> bool {
@@ -525,6 +693,144 @@ mod tests {
         assert!(matches_glob("a/b/c", "a/**/c"));
         assert!(matches_glob("a/c", "a/**/c"));
         assert!(matches_glob("a/x/y/c", "a/**/c"));
+    }
+
+    #[test]
+    fn test_clean_package_file_reference() {
+        for (input, expected) in [
+            ("dist/index.js", Some("dist/index.js")),
+            ("./dist/index.js", Some("dist/index.js")),
+            (r"dist\index.js", Some("dist/index.js")),
+            ("/dist/index.js", None),
+            ("//dist/index.js", None),
+            ("././dist/index.js", None),
+            ("dist//index.js", None),
+            ("dist/../index.js", None),
+            ("C:/dist/index.js", None),
+            ("dist/", None),
+        ] {
+            assert_eq!(
+                clean_package_file_reference(input).as_deref(),
+                expected,
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_only_runtime_entrypoints_are_recovered_from_root_ignore() {
+        for bin in [r#""dist/cli.js""#, r#"{ "fixture": "dist/cli.js" }"#] {
+            let dir = TempDir::new().unwrap();
+            let root = dir.path();
+            let manifest = format!(
+                r#"{{
+  "name": "fixture",
+  "version": "1.0.0",
+  "main": "./dist/index.js",
+  "browser": "dist/browser.js",
+  "types": "dist/index.d.ts",
+  "bin": {bin}
+}}"#
+            );
+            fs::write(root.join("package.json"), &manifest).unwrap();
+            fs::write(root.join(".npmignore"), "dist/\n").unwrap();
+            fs::create_dir(root.join("dist")).unwrap();
+            for file in ["index.js", "browser.js", "index.d.ts", "cli.js"] {
+                fs::write(root.join("dist").join(file), file).unwrap();
+            }
+
+            let files = collect_pack_files(root, &parse_json(&manifest)).unwrap();
+            assert!(has(&files, "dist/index.js"));
+            assert!(has(&files, "dist/browser.js"));
+            assert!(has(&files, "dist/cli.js"));
+            assert!(!has(&files, "dist/index.d.ts"));
+        }
+    }
+
+    #[test]
+    fn test_nested_only_ignore_does_not_trigger_entrypoint_recovery() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let manifest = r#"{
+  "name": "fixture",
+  "version": "1.0.0",
+  "browser": "dist/browser.js"
+}"#;
+        fs::write(root.join("package.json"), manifest).unwrap();
+        fs::write(root.join(".npmignore"), "").unwrap();
+        fs::create_dir(root.join("dist")).unwrap();
+        fs::write(root.join("dist/.npmignore"), "browser.js\n").unwrap();
+        fs::write(root.join("dist/browser.js"), "browser").unwrap();
+
+        let files = collect_pack_files(root, &parse_json(manifest)).unwrap();
+        assert!(!has(&files, "dist/browser.js"));
+    }
+
+    #[test]
+    fn test_root_parent_ignore_with_entrypoint_negation_is_recovered() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let manifest = r#"{
+  "name": "fixture",
+  "version": "1.0.0",
+  "browser": "dist/browser.js"
+}"#;
+        fs::write(root.join("package.json"), manifest).unwrap();
+        fs::write(root.join(".npmignore"), "dist/\n!dist/browser.js\n").unwrap();
+        fs::create_dir(root.join("dist")).unwrap();
+        fs::write(root.join("dist/browser.js"), "browser").unwrap();
+
+        let files = collect_pack_files(root, &parse_json(manifest)).unwrap();
+        assert!(has(&files, "dist/browser.js"));
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    #[test]
+    fn test_hard_exclusions_are_case_insensitive() {
+        assert!(is_excluded_file(".NPMRC"));
+        assert!(is_excluded_directory("NODE_MODULES"));
+
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let manifest = r#"{
+  "name": "fixture",
+  "version": "1.0.0",
+  "browser": ".NPMRC"
+}"#;
+        fs::write(root.join("package.json"), manifest).unwrap();
+        fs::write(root.join(".npmignore"), "*\n").unwrap();
+        fs::write(
+            root.join(".npmrc"),
+            "//registry.example/:_authToken=secret\n",
+        )
+        .unwrap();
+
+        let files = collect_pack_files(root, &parse_json(manifest)).unwrap();
+        assert!(!has(&files, ".NPMRC"));
+        assert!(!has(&files, ".npmrc"));
+
+        let alias_dir = TempDir::new().unwrap();
+        let alias_root = alias_dir.path();
+        let alias_manifest = r#"{
+  "name": "fixture",
+  "version": "1.0.0",
+  "browser": "dist/browser.js"
+}"#;
+        fs::write(alias_root.join("package.json"), alias_manifest).unwrap();
+        fs::write(alias_root.join(".npmignore"), "dist/browser.js\n").unwrap();
+        fs::create_dir(alias_root.join("dist")).unwrap();
+        fs::write(alias_root.join("dist/Browser.js"), "browser").unwrap();
+
+        let files = collect_pack_files(alias_root, &parse_json(alias_manifest)).unwrap();
+        assert_eq!(
+            files
+                .iter()
+                .filter(|(path, _)| path
+                    .to_string_lossy()
+                    .eq_ignore_ascii_case("dist/browser.js"))
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/crates/pm/src/service/pm_pack.rs
+++ b/crates/pm/src/service/pm_pack.rs
@@ -4,7 +4,7 @@ use flate2::write::GzEncoder;
 use ignore::WalkBuilder;
 use std::fs;
 use std::io::{ErrorKind, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use tar::{Builder, EntryType, Header};
 use utoo_ruborist::manifest::PackageJson;
 
@@ -56,6 +56,7 @@ pub async fn pack(package_root: &Path, output: ScriptOutput) -> Result<PackResul
     // rewritten package.json (version bump, stripped fields). The `pkg` above
     // is cached from before the script ran, so read the current file from disk.
     let pkg: PackageJson = load_package_json(package_root).await?;
+    validate_pack_name(&pkg.name)?;
 
     // Normalize dependency protocols and publish-time manifest overrides.
     // `None` means there was nothing to rewrite, in which case the on-disk
@@ -63,9 +64,7 @@ pub async fn pack(package_root: &Path, output: ScriptOutput) -> Result<PackResul
     let normalized = normalize_publish_manifest(package_root, &pkg).await?;
     let pkg_json_override = normalized.as_ref().map(serialize_manifest).transpose()?;
     let packed_manifest = normalized.unwrap_or_else(|| pkg.clone());
-    if packed_manifest.name.is_empty() {
-        anyhow::bail!("Missing 'name' field in package.json");
-    }
+    validate_pack_name(&packed_manifest.name)?;
 
     // collect_pack_files uses ignore::WalkBuilder which does synchronous I/O.
     // Run on a blocking thread to avoid stalling the tokio runtime.
@@ -113,6 +112,54 @@ pub async fn pack(package_root: &Path, output: ScriptOutput) -> Result<PackResul
         unpacked_size,
         packed_size,
         manifest: packed_manifest,
+    })
+}
+
+/// Validate both the source and published package names using pnpm's
+/// `validate-npm-package-name` `validForOldPackages` rules.
+fn validate_pack_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("Missing 'name' field in package.json");
+    }
+    if !is_valid_old_npm_package_name(name) {
+        anyhow::bail!("Invalid package name \"{name}\".");
+    }
+    Ok(())
+}
+
+fn is_valid_old_npm_package_name(name: &str) -> bool {
+    if name.is_empty()
+        || name.starts_with('.')
+        || name.starts_with('-')
+        || name.starts_with('_')
+        || name.trim() != name
+        || name.eq_ignore_ascii_case("node_modules")
+        || name.eq_ignore_ascii_case("favicon.ico")
+    {
+        return false;
+    }
+    if is_url_friendly_package_name_part(name) {
+        return true;
+    }
+
+    let Some(rest) = name.strip_prefix('@') else {
+        return false;
+    };
+    let Some((scope, package)) = rest.split_once('/') else {
+        return false;
+    };
+    !scope.is_empty()
+        && !package.is_empty()
+        && !package.contains('/')
+        && !package.starts_with('.')
+        && is_url_friendly_package_name_part(scope)
+        && is_url_friendly_package_name_part(package)
+}
+
+fn is_url_friendly_package_name_part(value: &str) -> bool {
+    value.chars().all(|ch| {
+        ch.is_ascii_alphanumeric()
+            || matches!(ch, '-' | '_' | '.' | '!' | '~' | '*' | '\'' | '(' | ')')
     })
 }
 
@@ -246,8 +293,83 @@ fn collect_pack_files(
         }
     }
 
+    // Root ignore files can prune a referenced file's parent directory before
+    // the inclusion check sees it. Re-check exact manifest references without
+    // following symlinks so main/browser/types/bin remain mandatory but cannot
+    // escape the package root.
+    add_missing_referenced_files(package_root, &referenced_files, &mut files)?;
+
     files.sort_by(|(a, _), (b, _)| a.cmp(b));
     Ok(files)
+}
+
+fn add_missing_referenced_files(
+    package_root: &Path,
+    referenced_files: &std::collections::HashSet<String>,
+    files: &mut Vec<(PathBuf, u64)>,
+) -> Result<()> {
+    let mut collected: std::collections::HashSet<PathBuf> =
+        files.iter().map(|(path, _)| path.clone()).collect();
+    for referenced in referenced_files {
+        if referenced.ends_with('/') {
+            continue;
+        }
+        let relative = PathBuf::from(referenced);
+        if collected.contains(&relative) || !is_safe_referenced_path(&relative) {
+            continue;
+        }
+        if let Some(size) = referenced_file_size(package_root, &relative)? {
+            collected.insert(relative.clone());
+            files.push((relative, size));
+        }
+    }
+    Ok(())
+}
+
+fn is_safe_referenced_path(path: &Path) -> bool {
+    let mut has_component = false;
+    let mut components = path.components().peekable();
+    while let Some(component) = components.next() {
+        let Component::Normal(name) = component else {
+            return false;
+        };
+        has_component = true;
+        let name = name.to_string_lossy();
+        if components.peek().is_some() && ALWAYS_EXCLUDE_DIRS.contains(&name.as_ref()) {
+            return false;
+        }
+    }
+    has_component
+        && path
+            .file_name()
+            .is_some_and(|name| !is_excluded_file(&name.to_string_lossy()))
+}
+
+fn referenced_file_size(package_root: &Path, relative: &Path) -> Result<Option<u64>> {
+    let components: Vec<_> = relative.components().collect();
+    let mut current = package_root.to_path_buf();
+    for (index, component) in components.iter().enumerate() {
+        current.push(component.as_os_str());
+        let metadata = match fs::symlink_metadata(&current) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("Failed to inspect {}", current.display()));
+            }
+        };
+        if metadata.file_type().is_symlink() {
+            return Ok(None);
+        }
+        let is_last = index + 1 == components.len();
+        if is_last {
+            return Ok(metadata.is_file().then_some(metadata.len()));
+        }
+        if !metadata.is_dir() {
+            return Ok(None);
+        }
+    }
+    Ok(None)
 }
 
 fn compile_whitelist(
@@ -405,6 +527,45 @@ mod tests {
         assert!(matches_glob("a/x/y/c", "a/**/c"));
     }
 
+    #[test]
+    fn test_valid_old_npm_package_name() {
+        for valid in [
+            "foo",
+            "foo-bar",
+            "foo.bar",
+            "foo_bar",
+            "@scope/foo",
+            "@scope/_foo",
+            "Foo",
+            "1.2.3",
+        ] {
+            assert!(
+                is_valid_old_npm_package_name(valid),
+                "{valid} should be valid"
+            );
+        }
+        for invalid in [
+            "",
+            ".foo",
+            "-foo",
+            "_foo",
+            " foo",
+            "foo ",
+            "bad name",
+            "node_modules",
+            "favicon.ico",
+            "@scope/.foo",
+            "@scope/foo/bar",
+            "@/foo",
+            "@scope/",
+        ] {
+            assert!(
+                !is_valid_old_npm_package_name(invalid),
+                "{invalid} should be invalid"
+            );
+        }
+    }
+
     fn parse_json(s: &str) -> serde_json::Value {
         serde_json::from_str(s).unwrap()
     }
@@ -452,6 +613,45 @@ mod tests {
         assert!(has(&files, "README.md"));
         assert!(has(&files, "dist/bundle.js"));
         assert!(!has(&files, "index.js"));
+    }
+
+    #[test]
+    fn test_referenced_file_cannot_escape_package_root() {
+        let parent = TempDir::new().unwrap();
+        let root = parent.path().join("package");
+        fs::create_dir(&root).unwrap();
+        fs::write(
+            root.join("package.json"),
+            r#"{"name":"t","version":"1.0.0","browser":"../secret.js"}"#,
+        )
+        .unwrap();
+        fs::write(parent.path().join("secret.js"), "secret").unwrap();
+
+        let data = parse_json(r#"{"name":"t","version":"1.0.0","browser":"../secret.js"}"#);
+        let files = collect_pack_files(&root, &data).unwrap();
+        assert!(!has(&files, "../secret.js"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_referenced_file_does_not_follow_symlinked_directory() {
+        use std::os::unix::fs::symlink;
+
+        let project = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let root = project.path();
+        fs::write(
+            root.join("package.json"),
+            r#"{"name":"t","version":"1.0.0","browser":"dist/browser.js"}"#,
+        )
+        .unwrap();
+        fs::write(root.join(".gitignore"), "dist/\n").unwrap();
+        fs::write(outside.path().join("browser.js"), "secret").unwrap();
+        symlink(outside.path(), root.join("dist")).unwrap();
+
+        let data = parse_json(r#"{"name":"t","version":"1.0.0","browser":"dist/browser.js"}"#);
+        let files = collect_pack_files(root, &data).unwrap();
+        assert!(!has(&files, "dist/browser.js"));
     }
 
     #[test]

--- a/crates/pm/src/service/pm_pack.rs
+++ b/crates/pm/src/service/pm_pack.rs
@@ -825,9 +825,9 @@ mod tests {
         assert_eq!(
             files
                 .iter()
-                .filter(|(path, _)| path
-                    .to_string_lossy()
-                    .eq_ignore_ascii_case("dist/browser.js"))
+                .filter(|(path, _)| {
+                    normalize_path(&path.to_string_lossy()).eq_ignore_ascii_case("dist/browser.js")
+                })
                 .count(),
             1
         );

--- a/crates/pm/src/service/pm_pack.rs
+++ b/crates/pm/src/service/pm_pack.rs
@@ -63,6 +63,9 @@ pub async fn pack(package_root: &Path, output: ScriptOutput) -> Result<PackResul
     let normalized = normalize_publish_manifest(package_root, &pkg).await?;
     let pkg_json_override = normalized.as_ref().map(serialize_manifest).transpose()?;
     let packed_manifest = normalized.unwrap_or_else(|| pkg.clone());
+    if packed_manifest.name.is_empty() {
+        anyhow::bail!("Missing 'name' field in package.json");
+    }
 
     // collect_pack_files uses ignore::WalkBuilder which does synchronous I/O.
     // Run on a blocking thread to avoid stalling the tokio runtime.
@@ -207,7 +210,7 @@ fn append_override<W: Write>(
 /// 3. **Inclusion check** (determines whether a surviving file is collected):
 ///    - `is_always_included`: `package.json`, `readme*`, `license*` — always
 ///      included even if not listed in the `files` whitelist
-///    - `referenced_files`: paths declared in `main`, `bin`, `types`, `typings` — always included
+///    - `referenced_files`: paths declared in `main`, `browser`, `bin`, `types`, `typings` — always included
 ///    - Whitelist: if `files` field exists, the file must match a pattern; otherwise all files
 ///      that passed layers 1–2 are included
 fn collect_pack_files(
@@ -267,7 +270,7 @@ fn compile_whitelist(
 
 fn collect_referenced_files(pkg: &serde_json::Value) -> std::collections::HashSet<String> {
     let mut refs = std::collections::HashSet::new();
-    for key in ["main", "types", "typings"] {
+    for key in ["main", "browser", "types", "typings"] {
         if let Some(s) = pkg.get(key).and_then(|v| v.as_str()) {
             refs.insert(normalize_path(s));
         }

--- a/crates/pm/src/service/publish.rs
+++ b/crates/pm/src/service/publish.rs
@@ -125,8 +125,8 @@ pub async fn publish(opts: &PublishOptions<'_>) -> Result<PublishOutcome> {
         None => auth::require_token(opts.registry).await?,
     };
 
-    // Reuse the manifest packed into the tarball (with `workspace:`/`catalog:`
-    // already rewritten) so the registry metadata matches the tarball contents.
+    // Reuse the normalized manifest packed into the tarball so the registry
+    // metadata matches the tarball contents.
     let payload = PublishPayload::new(&PublishPayloadInput {
         package_json: &pack_result.manifest,
         name: &pack_result.name,

--- a/crates/pm/src/service/publish_manifest.rs
+++ b/crates/pm/src/service/publish_manifest.rs
@@ -11,9 +11,12 @@
 //!   the linked workspace package's version (see [`resolve_workspace_spec`])
 //! - `catalog:` / `catalog:<name>` → the version pinned in the catalog
 //!   (`pnpm-workspace.yaml` → `.utoo.toml`, see [`resolve_catalog_spec`])
+//! - pnpm's allowlisted `publishConfig` manifest overrides (including
+//!   `main`, `types`, `bin`, and `exports`) → their top-level fields
 //!
-//! It is a no-op (returns `None`) when the manifest contains neither protocol,
-//! so standalone packages keep their on-disk `package.json` byte-for-byte.
+//! It is a no-op (returns `None`) when the manifest contains neither dependency
+//! protocol nor a supported publish-time override, so ordinary packages keep
+//! their on-disk `package.json` byte-for-byte.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -25,9 +28,9 @@ use utoo_ruborist::spec::{Catalogs, Protocol, resolve_catalog_spec, resolve_work
 use crate::helper::ruborist_context::Context;
 use crate::util::config_file::Config;
 
-/// Return a normalized clone of `pkg` with `workspace:`/`catalog:` dependency
-/// specifiers rewritten to concrete version ranges, or `Ok(None)` when there is
-/// nothing to rewrite.
+/// Return a normalized clone of `pkg` with publish-time overrides applied and
+/// `workspace:`/`catalog:` dependency specifiers rewritten to concrete version
+/// ranges, or `Ok(None)` when there is nothing to rewrite.
 ///
 /// `package_root` is the directory of the package being packed; it is used to
 /// locate the surrounding workspace when resolving `workspace:` specifiers.
@@ -37,38 +40,114 @@ pub(crate) async fn normalize_publish_manifest(
 ) -> Result<Option<PackageJson>> {
     let needs_workspace = has_protocol(pkg, Protocol::Workspace);
     let needs_catalog = has_protocol(pkg, Protocol::Catalog);
-    if !needs_workspace && !needs_catalog {
+    let needs_publish_override = has_publish_config_overrides(pkg);
+    if !needs_workspace && !needs_catalog && !needs_publish_override {
         return Ok(None);
     }
 
-    // Both protocols resolve against the surrounding workspace root: sibling
-    // members supply `workspace:` versions, and the root `.utoo.toml` holds the
-    // catalog definitions (migrated from `pnpm-workspace.yaml`). `pm-pack` runs
-    // inside a member dir, so we must look up the root rather than the cwd.
-    let root = Context::discovery()
-        .find_root_path(package_root)
-        .await
-        .with_context(|| {
-            format!(
-                "failed to locate the workspace root for {}",
-                package_root.display()
-            )
-        })?;
-
-    let workspace_versions = if needs_workspace {
-        discover_workspace_versions(&root).await?
+    let (workspace_versions, catalogs) = if needs_workspace || needs_catalog {
+        // Both protocols resolve against the surrounding workspace root:
+        // sibling members supply `workspace:` versions, and the root
+        // `.utoo.toml` holds catalog definitions. `pm-pack` runs inside a
+        // member dir, so look up the root rather than assuming the cwd.
+        let root = Context::discovery()
+            .find_root_path(package_root)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to locate the workspace root for {}",
+                    package_root.display()
+                )
+            })?;
+        let workspace_versions = if needs_workspace {
+            discover_workspace_versions(&root).await?
+        } else {
+            HashMap::new()
+        };
+        let catalogs = if needs_catalog {
+            load_catalogs(&root).await?
+        } else {
+            Catalogs::new()
+        };
+        (workspace_versions, catalogs)
     } else {
-        HashMap::new()
-    };
-    let catalogs = if needs_catalog {
-        load_catalogs(&root).await?
-    } else {
-        Catalogs::new()
+        (HashMap::new(), Catalogs::new())
     };
 
     let mut normalized = pkg.clone();
     rewrite_dep_specs(&mut normalized, &workspace_versions, &catalogs)?;
+    apply_publish_config_overrides(&mut normalized)?;
     Ok(Some(normalized))
+}
+
+/// pnpm's allowlist of package manifest fields that may be replaced at pack
+/// time. Operational settings such as `registry`, `tag`, `access`, and
+/// `provenance` intentionally remain nested under `publishConfig`.
+const PUBLISH_CONFIG_OVERRIDE_FIELDS: &[&str] = &[
+    "name",
+    "bin",
+    "engines",
+    "type",
+    "imports",
+    "main",
+    "module",
+    "typings",
+    "types",
+    "exports",
+    "browser",
+    "esnext",
+    "es2015",
+    "unpkg",
+    "umd:main",
+    "os",
+    "cpu",
+    "libc",
+    "typesVersions",
+];
+
+/// Whether any pnpm-compatible publish-time manifest override is present,
+/// including an explicit JSON `null` value.
+fn has_publish_config_overrides(pkg: &PackageJson) -> bool {
+    pkg.publish_config.as_ref().is_some_and(|config| {
+        PUBLISH_CONFIG_OVERRIDE_FIELDS
+            .iter()
+            .any(|field| config.extra.contains_key(*field))
+    })
+}
+
+/// Apply pnpm-compatible `publishConfig` overrides to the packed manifest
+/// without changing the source manifest on disk. Consumed keys are removed,
+/// and an empty `publishConfig` object is omitted from package.json.
+fn apply_publish_config_overrides(pkg: &mut PackageJson) -> Result<bool> {
+    if !has_publish_config_overrides(pkg) {
+        return Ok(false);
+    }
+
+    let mut manifest = pkg.to_value();
+    let root = manifest
+        .as_object_mut()
+        .context("package manifest must serialize to a JSON object")?;
+    let Some(serde_json::Value::Object(mut publish_config)) = root.remove("publishConfig") else {
+        return Ok(false);
+    };
+
+    let mut applied = false;
+    for field in PUBLISH_CONFIG_OVERRIDE_FIELDS {
+        if let Some(value) = publish_config.remove(*field) {
+            root.insert((*field).to_string(), value);
+            applied = true;
+        }
+    }
+    if !publish_config.is_empty() {
+        root.insert(
+            "publishConfig".to_string(),
+            serde_json::Value::Object(publish_config),
+        );
+    }
+
+    *pkg = PackageJson::from_value(&manifest)
+        .context("publishConfig contains an invalid package manifest override")?;
+    Ok(applied)
 }
 
 /// Rewrite every `workspace:`/`catalog:` specifier across all dependency maps
@@ -183,6 +262,7 @@ fn has_protocol(pkg: &PackageJson, protocol: Protocol) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     fn pkg_with_deps(deps: &[(&str, &str)]) -> PackageJson {
         let map: HashMap<String, String> = deps
@@ -299,5 +379,107 @@ mod tests {
         let plain = pkg_with_deps(&[("a", "^1.0.0")]);
         assert!(!has_protocol(&plain, Protocol::Workspace));
         assert!(!has_protocol(&plain, Protocol::Catalog));
+    }
+
+    #[tokio::test]
+    async fn applies_publish_config_overrides_without_mutating_source_manifest() {
+        let pkg = PackageJson::from_value(&json!({
+            "name": "fixture",
+            "version": "1.0.0",
+            "main": "./src/index.ts",
+            "types": "./src/index.ts",
+            "bin": {
+                "fixture": "./src/cli.ts"
+            },
+            "exports": {
+                ".": "./src/index.ts",
+                "./feature": "./src/feature.ts"
+            },
+            "publishConfig": {
+                "main": "./dist/index.js",
+                "types": "./dist/index.d.ts",
+                "bin": {
+                    "fixture": "./dist/cli.js"
+                },
+                "exports": {
+                    ".": {
+                        "import": "./dist/index.js",
+                        "types": "./dist/index.d.ts"
+                    },
+                    "./feature": "./dist/feature.js"
+                }
+            }
+        }))
+        .unwrap();
+        let source = pkg.to_value();
+
+        let normalized = normalize_publish_manifest(Path::new("."), &pkg)
+            .await
+            .unwrap()
+            .unwrap();
+        let published = normalized.to_value();
+
+        assert_eq!(source["main"], "./src/index.ts");
+        assert_eq!(source["exports"]["."], "./src/index.ts");
+        assert_eq!(
+            source["publishConfig"]["exports"]["./feature"],
+            "./dist/feature.js"
+        );
+        assert_eq!(published["main"], "./dist/index.js");
+        assert_eq!(published["types"], "./dist/index.d.ts");
+        assert_eq!(published["bin"]["fixture"], "./dist/cli.js");
+        assert_eq!(published["exports"]["."]["import"], "./dist/index.js");
+        assert_eq!(published["exports"]["."]["types"], "./dist/index.d.ts");
+        assert_eq!(published["exports"]["./feature"], "./dist/feature.js");
+        assert!(published.get("publishConfig").is_none());
+    }
+
+    #[test]
+    fn applies_full_pnpm_allowlist_and_keeps_publish_options() {
+        let overrides = json!({
+            "name": "fixture-published",
+            "bin": { "fixture": "./dist/cli.js" },
+            "engines": { "node": ">=22" },
+            "type": "module",
+            "imports": { "#internal": "./dist/internal.js" },
+            "main": "./dist/index.js",
+            "module": "./dist/index.js",
+            "typings": "./dist/index.d.ts",
+            "types": "./dist/index.d.ts",
+            "exports": { ".": "./dist/index.js" },
+            "browser": "./dist/browser.js",
+            "esnext": "./dist/esnext.js",
+            "es2015": "./dist/es2015.js",
+            "unpkg": "./dist/index.min.js",
+            "umd:main": "./dist/index.umd.js",
+            "os": [ "darwin" ],
+            "cpu": [ "arm64" ],
+            "libc": [ "glibc" ],
+            "typesVersions": { "*": { "*": [ "dist/*" ] } }
+        });
+        let mut publish_config = overrides.as_object().unwrap().clone();
+        publish_config.insert(
+            "registry".to_string(),
+            json!("https://registry.example.com"),
+        );
+        publish_config.insert("customSetting".to_string(), json!(true));
+        let mut pkg = PackageJson::from_value(&json!({
+            "name": "fixture",
+            "version": "1.0.0",
+            "publishConfig": publish_config
+        }))
+        .unwrap();
+
+        assert!(apply_publish_config_overrides(&mut pkg).unwrap());
+        let published = pkg.to_value();
+        for (field, expected) in overrides.as_object().unwrap() {
+            assert_eq!(&published[field], expected, "override field {field}");
+            assert!(published["publishConfig"].get(field).is_none());
+        }
+        assert_eq!(
+            published["publishConfig"]["registry"],
+            "https://registry.example.com"
+        );
+        assert_eq!(published["publishConfig"]["customSetting"], true);
     }
 }

--- a/crates/pm/tests/cli_contract.rs
+++ b/crates/pm/tests/cli_contract.rs
@@ -208,6 +208,7 @@ fn pack_applies_publish_config_overrides_to_tarball_only() {
   "version": "1.0.0",
   "type": "module",
   "main": "./src/index.ts",
+  "browser": "./src/browser.ts",
   "types": "./src/index.ts",
   "bin": {
     "fixture": "./src/cli.ts"
@@ -218,6 +219,7 @@ fn pack_applies_publish_config_overrides_to_tarball_only() {
   "publishConfig": {
     "name": "fixture-published",
     "main": "./dist/index.js",
+    "browser": "./dist/browser.js",
     "types": "./dist/index.d.ts",
     "bin": {
       "fixture": "./dist/cli.js"
@@ -239,6 +241,11 @@ fn pack_applies_publish_config_overrides_to_tarball_only() {
     )
     .unwrap();
     fs::write(
+        project.path().join("src/browser.ts"),
+        "export const browserSource = true;\n",
+    )
+    .unwrap();
+    fs::write(
         project.path().join("src/cli.ts"),
         "console.log('source');\n",
     )
@@ -247,6 +254,11 @@ fn pack_applies_publish_config_overrides_to_tarball_only() {
     fs::write(
         project.path().join("dist/index.js"),
         "export const compiled = true;\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("dist/browser.js"),
+        "export const browserCompiled = true;\n",
     )
     .unwrap();
     fs::write(
@@ -292,6 +304,7 @@ fn pack_applies_publish_config_overrides_to_tarball_only() {
 
     assert_eq!(packed_manifest["name"], "fixture-published");
     assert_eq!(packed_manifest["main"], "./dist/index.js");
+    assert_eq!(packed_manifest["browser"], "./dist/browser.js");
     assert_eq!(packed_manifest["types"], "./dist/index.d.ts");
     assert_eq!(packed_manifest["bin"]["fixture"], "./dist/cli.js");
     assert_eq!(packed_manifest["exports"]["."]["import"], "./dist/index.js");
@@ -313,11 +326,46 @@ fn pack_applies_publish_config_overrides_to_tarball_only() {
     assert_eq!(
         files,
         [
+            "dist/browser.js",
             "dist/cli.js",
             "dist/index.d.ts",
             "dist/index.js",
             "package.json"
         ]
+    );
+}
+
+#[test]
+fn pack_rejects_empty_publish_config_name() {
+    let project = tempdir().unwrap();
+    fs::write(
+        project.path().join("package.json"),
+        r#"{
+  "name": "fixture",
+  "version": "1.0.0",
+  "publishConfig": {
+    "name": ""
+  }
+}"#,
+    )
+    .unwrap();
+
+    let output = utoo()
+        .current_dir(project.path())
+        .args(["--json", "pm-pack", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert_eq!(stderr.lines().count(), 1);
+    let value: Value = serde_json::from_str(&stderr).unwrap();
+    assert_eq!(value["command"], "pack");
+    assert_eq!(value["ok"], false);
+    assert_eq!(
+        value["error"]["message"],
+        "Missing 'name' field in package.json"
     );
 }
 

--- a/crates/pm/tests/cli_contract.rs
+++ b/crates/pm/tests/cli_contract.rs
@@ -370,6 +370,114 @@ fn pack_rejects_empty_publish_config_name() {
 }
 
 #[test]
+fn pack_rejects_invalid_publish_config_name() {
+    let project = tempdir().unwrap();
+    fs::write(
+        project.path().join("package.json"),
+        r#"{
+  "name": "fixture",
+  "version": "1.0.0",
+  "publishConfig": {
+    "name": "bad name"
+  }
+}"#,
+    )
+    .unwrap();
+
+    let output = utoo()
+        .current_dir(project.path())
+        .args(["--json", "pm-pack", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let value: Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert_eq!(value["command"], "pack");
+    assert_eq!(value["ok"], false);
+    assert_eq!(
+        value["error"]["message"],
+        "Invalid package name \"bad name\"."
+    );
+}
+
+#[test]
+fn pack_rejects_missing_source_name_with_publish_config_name() {
+    let project = tempdir().unwrap();
+    fs::write(
+        project.path().join("package.json"),
+        r#"{
+  "version": "1.0.0",
+  "publishConfig": {
+    "name": "fixture-published"
+  }
+}"#,
+    )
+    .unwrap();
+
+    let output = utoo()
+        .current_dir(project.path())
+        .args(["--json", "pm-pack", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let value: Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert_eq!(value["command"], "pack");
+    assert_eq!(value["ok"], false);
+    assert_eq!(
+        value["error"]["message"],
+        "Missing 'name' field in package.json"
+    );
+}
+
+#[test]
+fn pack_keeps_publish_config_browser_when_ignored() {
+    for ignore_file in [".gitignore", ".npmignore"] {
+        let project = tempdir().unwrap();
+        fs::write(
+            project.path().join("package.json"),
+            r#"{
+  "name": "fixture",
+  "version": "1.0.0",
+  "publishConfig": {
+    "browser": "./dist/browser.js"
+  }
+}"#,
+        )
+        .unwrap();
+        fs::write(project.path().join(ignore_file), "dist/\n").unwrap();
+        fs::create_dir(project.path().join("dist")).unwrap();
+        fs::write(
+            project.path().join("dist/browser.js"),
+            "export const browser = true;\n",
+        )
+        .unwrap();
+
+        let output = utoo()
+            .current_dir(project.path())
+            .args(["--json", "pm-pack", "--dry-run"])
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{ignore_file}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+        let files = value["result"]["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|file| file["path"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(files, ["dist/browser.js", "package.json"], "{ignore_file}");
+    }
+}
+
+#[test]
 fn install_json_lifecycle_success_is_one_clean_document() {
     let project = tempdir().unwrap();
     write_lifecycle_project(project.path(), 0);

--- a/crates/pm/tests/cli_contract.rs
+++ b/crates/pm/tests/cli_contract.rs
@@ -5,7 +5,9 @@ use std::path::Path;
 use std::process::{Command, Output, Stdio};
 use std::thread;
 
+use flate2::read::GzDecoder;
 use serde_json::Value;
+use tar::Archive;
 use tempfile::tempdir;
 
 fn utoo() -> Command {
@@ -196,6 +198,127 @@ fn pack_json_is_one_clean_document() {
     assert_eq!(value["result"]["name"], "fixture");
     assert_eq!(value["result"]["dryRun"], true);
     assert_eq!(value["result"]["tarballPath"], Value::Null);
+}
+
+#[test]
+fn pack_applies_publish_config_overrides_to_tarball_only() {
+    let project = tempdir().unwrap();
+    let source_manifest = r#"{
+  "name": "fixture",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "bin": {
+    "fixture": "./src/cli.ts"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "name": "fixture-published",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "bin": {
+      "fixture": "./dist/cli.js"
+    },
+    "exports": {
+      ".": {
+        "import": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      }
+    }
+  },
+  "files": []
+}"#;
+    fs::write(project.path().join("package.json"), source_manifest).unwrap();
+    fs::create_dir(project.path().join("src")).unwrap();
+    fs::write(
+        project.path().join("src/index.ts"),
+        "export const source = true;\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("src/cli.ts"),
+        "console.log('source');\n",
+    )
+    .unwrap();
+    fs::create_dir(project.path().join("dist")).unwrap();
+    fs::write(
+        project.path().join("dist/index.js"),
+        "export const compiled = true;\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("dist/index.d.ts"),
+        "export declare const compiled: true;\n",
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("dist/cli.js"),
+        "console.log('compiled');\n",
+    )
+    .unwrap();
+
+    let output = utoo()
+        .current_dir(project.path())
+        .args(["--json", "pm-pack"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["result"]["name"], "fixture-published");
+    assert_eq!(value["result"]["filename"], "fixture-published-1.0.0.tgz");
+    let tarball_path = value["result"]["tarballPath"].as_str().unwrap();
+    let decoder = GzDecoder::new(fs::File::open(tarball_path).unwrap());
+    let mut archive = Archive::new(decoder);
+    let mut packed_manifest = None;
+    for entry in archive.entries().unwrap() {
+        let mut entry = entry.unwrap();
+        if entry.path().unwrap() == Path::new("package/package.json") {
+            let mut contents = String::new();
+            entry.read_to_string(&mut contents).unwrap();
+            packed_manifest = Some(serde_json::from_str::<Value>(&contents).unwrap());
+            break;
+        }
+    }
+    let packed_manifest = packed_manifest.expect("tarball should contain package/package.json");
+
+    assert_eq!(packed_manifest["name"], "fixture-published");
+    assert_eq!(packed_manifest["main"], "./dist/index.js");
+    assert_eq!(packed_manifest["types"], "./dist/index.d.ts");
+    assert_eq!(packed_manifest["bin"]["fixture"], "./dist/cli.js");
+    assert_eq!(packed_manifest["exports"]["."]["import"], "./dist/index.js");
+    assert_eq!(
+        packed_manifest["exports"]["."]["types"],
+        "./dist/index.d.ts"
+    );
+    assert!(packed_manifest.get("publishConfig").is_none());
+    assert_eq!(
+        fs::read_to_string(project.path().join("package.json")).unwrap(),
+        source_manifest
+    );
+    let files = value["result"]["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|file| file["path"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        files,
+        [
+            "dist/cli.js",
+            "dist/index.d.ts",
+            "dist/index.js",
+            "package.json"
+        ]
+    );
 }
 
 #[test]

--- a/crates/ruborist/src/model/package_json.rs
+++ b/crates/ruborist/src/model/package_json.rs
@@ -341,6 +341,11 @@ pub struct PublishConfig {
     /// Whether to generate and attach a signed provenance attestation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provenance: Option<bool>,
+
+    /// Preserve publish-time manifest overrides and other package-manager
+    /// extensions that utoo does not model explicitly.
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
 }
 
 /// Empty map constant for convenience methods that return references.
@@ -659,7 +664,10 @@ mod tests {
             "publishConfig": {
                 "tag": "beta",
                 "registry": "https://custom.registry.org",
-                "access": "public"
+                "access": "public",
+                "exports": {
+                    ".": "./dist/index.js"
+                }
             }
         });
 
@@ -678,6 +686,7 @@ mod tests {
         assert_eq!(pc.tag.as_deref(), Some("beta"));
         assert_eq!(pc.registry.as_deref(), Some("https://custom.registry.org"));
         assert_eq!(pc.access.as_deref(), Some("public"));
+        assert_eq!(pc.extra["exports"]["."], "./dist/index.js");
 
         // Round-trip: ensure new fields survive to_value
         let rt = pkg.to_value();
@@ -685,6 +694,7 @@ mod tests {
         assert_eq!(rt["private"], true);
         assert_eq!(rt["main"], "./lib/index.js");
         assert_eq!(rt["publishConfig"]["tag"], "beta");
+        assert_eq!(rt["publishConfig"]["exports"]["."], "./dist/index.js");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- apply pnpm-compatible allowlisted `publishConfig` fields to the packed manifest
- keep operational publish settings such as `registry`, `tag`, `access`, and `provenance` under `publishConfig`
- select always-included `main`, `types`, and `bin` files from the normalized publish manifest
- reuse the same normalized manifest for the tarball and registry publish payload without mutating the source `package.json`

The supported override fields match pnpm: `name`, `bin`, `engines`, `type`, `imports`, `main`, `module`, `typings`, `types`, `exports`, `browser`, `esnext`, `es2015`, `unpkg`, `umd:main`, `os`, `cpu`, `libc`, and `typesVersions`.

## Validation

- `cargo test -p utoo-pm`
- `cargo test -p utoo-ruborist`
- focused CLI tarball contract covering source-to-dist `main`, `types`, `bin`, `exports`, and package name overrides
- `cargo clippy --all-targets -- -D warnings --no-deps`
- `cargo fmt --all --check`
- `git diff --check`