### PR TITLE
fix(pack): return 404 for missing static assets

### DIFF
--- a/packages/pack/src/__test__/serveClientPaths.test.ts
+++ b/packages/pack/src/__test__/serveClientPaths.test.ts
@@ -82,14 +82,19 @@ function runServeClientPathsFixture() {
 }
 
 describe("serve client paths", () => {
-  it("exposes initial client paths without webpack stats", async () => {
+  it("serves initial client paths with correct HTTP statuses", async () => {
     await expect(runServeClientPathsFixture()).resolves.toMatchInlineSnapshot(`
       {
         "clientPaths": [
           "main.js",
           "src_index_<hash>.js",
         ],
+        "existingGetStatus": 200,
+        "missingGetStatus": 404,
+        "missingHeadStatus": 404,
         "statsGenerated": false,
+        "unsupportedMethodAllow": "GET, HEAD",
+        "unsupportedMethodStatus": 405,
       }
     `);
   }, 30_000);

--- a/packages/pack/src/__test__/serveClientPathsChild.ts
+++ b/packages/pack/src/__test__/serveClientPathsChild.ts
@@ -50,10 +50,24 @@ async function main() {
     throw new Error("serve onReady callback was not called");
   }
 
+  const origin = `http://127.0.0.1:${port}`;
+  const [existingGet, missingGet, missingHead, unsupportedMethod] =
+    await Promise.all([
+      fetch(`${origin}/main.js`),
+      fetch(`${origin}/favicon.ico`),
+      fetch(`${origin}/favicon.ico`, { method: "HEAD" }),
+      fetch(`${origin}/favicon.ico`, { method: "POST" }),
+    ]);
+
   console.log(
     `__CLIENT_PATHS_SNAPSHOT__${JSON.stringify({
       clientPaths: readyContext.clientPaths.map(normalizeFileName).sort(),
+      existingGetStatus: existingGet.status,
+      missingGetStatus: missingGet.status,
+      missingHeadStatus: missingHead.status,
       statsGenerated: fs.existsSync(statsPath),
+      unsupportedMethodAllow: unsupportedMethod.headers.get("allow"),
+      unsupportedMethodStatus: unsupportedMethod.status,
     })}`,
   );
   process.kill(process.pid, "SIGTERM");

--- a/packages/pack/src/commands/dev.ts
+++ b/packages/pack/src/commands/dev.ts
@@ -315,7 +315,12 @@ async function runDev(
     }),
   );
 
-  app.all("*", (c) => c.body(null, 405, { Allow: "GET, HEAD" }));
+  app.all("*", (c) => {
+    if (c.req.method === "GET" || c.req.method === "HEAD") {
+      return c.notFound();
+    }
+    return c.body(null, 405, { Allow: "GET, HEAD" });
+  });
 
   const server = honoServe({
     ...serveOptsBase,


### PR DESCRIPTION
## Summary

- return `404 Not Found` when `GET` or `HEAD` misses the dev server's static output
- keep `405 Method Not Allowed` with `Allow: GET, HEAD` for unsupported methods
- extend the real dev-server fixture to cover existing assets, missing assets, and unsupported methods

`serveStatic()` correctly calls `next()` when a file is absent, but the unconditional final `app.all("*")` handler previously converted those allowed-method misses into 405 responses.

## Tests

- `npm --workspace @utoo/pack test` (89 tests)
- `npm --workspace @utoo/pack run build:js`
- `cargo fmt --check`
- `npx tombi format --check`
- `npx biome ci`
- `typos`