### PR TITLE
feat(pack): support React 17 compiler target

### DIFF
--- a/crates/pack-schema/src/lib.rs
+++ b/crates/pack-schema/src/lib.rs
@@ -1304,6 +1304,8 @@ pub enum SchemaReactCompilerCompilationMode {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub enum SchemaReactCompilerTarget {
+    #[serde(rename = "17")]
+    React17,
     #[serde(rename = "18")]
     React18,
     #[serde(rename = "19")]

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/assert.js
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/assert.js
@@ -1,0 +1,14 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const output = fs
+  .readdirSync("output")
+  .filter((file) => file.endsWith(".js"))
+  .map((file) => fs.readFileSync(path.join("output", file), "utf8"))
+  .join("\n");
+
+assert.match(output, /"react-compiler-runtime"/);
+assert.doesNotMatch(output, /react\/compiler-runtime/);
+assert.match(output, /const \$ = .*\["c"\]\)\(\d+\)/);
+assert.match(output, /\$\[0\] !== count/);

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/config.json
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/config.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "entry": [
+      {
+        "import": "input/index.jsx",
+        "name": "main"
+      }
+    ],
+    "output": {
+      "path": "output"
+    },
+    "mode": "production",
+    "reactCompiler": {
+      "target": "17"
+    },
+    "optimization": {
+      "minify": false,
+      "moduleIds": "named"
+    },
+    "externals": {
+      "react-compiler-runtime": "commonjs react-compiler-runtime"
+    }
+  }
+}

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/input/index.jsx
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/input/index.jsx
@@ -1,0 +1,16 @@
+import { useState } from "react";
+
+export function Counter({ initialCount }) {
+  const [count, setCount] = useState(initialCount);
+  const doubled = count * 2;
+
+  return (
+    <div>
+      <p>{count}</p>
+      <p>{doubled}</p>
+      <button onClick={() => setCount(count + 1)}>increment</button>
+    </div>
+  );
+}
+
+console.log(Counter);

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/output/_root-of-the-server___0i2mg0h-qucpn.js
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/output/_root-of-the-server___0i2mg0h-qucpn.js
@@ -1,0 +1,116 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([typeof document === "object" ? document.currentScript : undefined,
+"[project]/node_modules/react/jsx-runtime.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+function jsx() {
+    return 'purposefully empty stub for react/jsx-runtime.js';
+}
+function jsxs() {
+    return 'purposefully empty stub for react/jsx-runtime.js';
+}
+__turbopack_context__.s([
+    "s",
+    0,
+    jsx,
+    "j",
+    0,
+    jsxs
+]);
+}),
+"[externals]/react-compiler-runtime [external] (react-compiler-runtime, cjs)", ((__turbopack_context__, module, exports) => {
+
+var mod = __turbopack_context__.x("react-compiler-runtime", () => require("react-compiler-runtime"));
+
+module.exports = mod;
+}),
+"[project]/node_modules/react/index.js [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+function jsx() {
+    return 'purposefully empty stub for react/index.js';
+}
+function useState(initialState) {
+    return [
+        initialState,
+        ()=>{}
+    ];
+}
+__turbopack_context__.s([
+    "f",
+    0,
+    useState
+]);
+}),
+"[project]/basic/react_compiler_react17/input/index.jsx [client] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/node_modules/react/jsx-runtime.js [client] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$externals$5d2f$react$2d$compiler$2d$runtime__$5b$external$5d$__$28$react$2d$compiler$2d$runtime$2c$__cjs$29$__ = __turbopack_context__.i("[externals]/react-compiler-runtime [external] (react-compiler-runtime, cjs)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/node_modules/react/index.js [client] (ecmascript)");
+;
+;
+;
+function Counter(t0) {
+    const $ = (0, __TURBOPACK__imported__module__$5b$externals$5d2f$react$2d$compiler$2d$runtime__$5b$external$5d$__$28$react$2d$compiler$2d$runtime$2c$__cjs$29$__["c"])(10);
+    const { initialCount } = t0;
+    const [count, setCount] = (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$index$2e$js__$5b$client$5d$__$28$ecmascript$29$__["f"])(initialCount);
+    const doubled = count * 2;
+    let t1;
+    if ($[0] !== count) {
+        t1 = /*#__PURE__*/ (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__["s"])("p", {
+            children: count
+        });
+        $[0] = count;
+        $[1] = t1;
+    } else {
+        t1 = $[1];
+    }
+    let t2;
+    if ($[2] !== doubled) {
+        t2 = /*#__PURE__*/ (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__["s"])("p", {
+            children: doubled
+        });
+        $[2] = doubled;
+        $[3] = t2;
+    } else {
+        t2 = $[3];
+    }
+    let t3;
+    if ($[4] !== count) {
+        t3 = /*#__PURE__*/ (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__["s"])("button", {
+            onClick: ()=>setCount(count + 1),
+            children: "increment"
+        });
+        $[4] = count;
+        $[5] = t3;
+    } else {
+        t3 = $[5];
+    }
+    let t4;
+    if ($[6] !== t1 || $[7] !== t2 || $[8] !== t3) {
+        t4 = /*#__PURE__*/ (0, __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$react$2f$jsx$2d$runtime$2e$js__$5b$client$5d$__$28$ecmascript$29$__["j"])("div", {
+            children: [
+                t1,
+                t2,
+                t3
+            ]
+        });
+        $[6] = t1;
+        $[7] = t2;
+        $[8] = t3;
+        $[9] = t4;
+    } else {
+        t4 = $[9];
+    }
+    return t4;
+}
+console.log(Counter);
+__turbopack_context__.s([
+    "Counter",
+    0,
+    Counter
+]);
+}),
+]);
+
+//# sourceMappingURL=_root-of-the-server___0i2mg0h-qucpn.js.map

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/output/_root-of-the-server___0i2mg0h-qucpn.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/output/_root-of-the-server___0i2mg0h-qucpn.js.map
@@ -1,0 +1,8 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/node_modules/react/jsx-runtime.js"],"sourcesContent":["export function jsx() {\n  return 'purposefully empty stub for react/jsx-runtime.js'\n}\nexport function jsxs() {\n  return 'purposefully empty stub for react/jsx-runtime.js'\n}\n"],"names":["jsx","jsxs"],"mappings":"AAAO,SAASA;IACd,OAAO;AACT;AACO,SAASC;IACd,OAAO;AACT","ignoreList":[0]}},
+    {"offset": {"line": 28, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/node_modules/react/index.js"],"sourcesContent":["export function jsx() {\n  return 'purposefully empty stub for react/index.js'\n}\nexport function useState(initialState) {\n  return [initialState, () => {}]\n}\n"],"names":["jsx","useState","initialState"],"mappings":"AAAO,SAASA;IACd,OAAO;AACT;AACO,SAASC,SAASC,YAAY;IACnC,OAAO;QAACA;QAAc,KAAO;KAAE;AACjC","ignoreList":[0]}},
+    {"offset": {"line": 46, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/basic/react_compiler_react17/input/index.jsx"],"sourcesContent":["import { useState } from \"react\";\n\nexport function Counter({ initialCount }) {\n  const [count, setCount] = useState(initialCount);\n  const doubled = count * 2;\n\n  return (\n    <div>\n      <p>{count}</p>\n      <p>{doubled}</p>\n      <button onClick={() => setCount(count + 1)}>increment</button>\n    </div>\n  );\n}\n\nconsole.log(Counter);\n"],"names":["console","log","Counter"],"mappings":";;AAAA;;;;AAEO;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAaPA,QAAQC,GAAG,CAACC"}}]
+}

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/output/main.js
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/output/main.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    typeof document === "object" ? document.currentScript : undefined,
+    {"otherChunks":["_root-of-the-server___0i2mg0h-qucpn.js"],"runtimeModuleIds":["[project]/basic/react_compiler_react17/input/index.jsx [client] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/output/main.js.map
+++ b/crates/pack-tests/tests/snapshot/basic/react_compiler_react17/output/main.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/packages/pack-shared/src/config.ts
+++ b/packages/pack-shared/src/config.ts
@@ -51,7 +51,8 @@ export type MdxOptions = boolean | MdxTransformOptions;
 
 export interface ReactCompilerOptions {
   compilationMode?: "infer" | "annotation" | "all";
-  target?: "18" | "19";
+  /** React version to target (default: "19"). React 17/18 require react-compiler-runtime. */
+  target?: "17" | "18" | "19";
 }
 
 export type ReactCompilerConfig = boolean | ReactCompilerOptions;

--- a/packages/pack/config_schema.json
+++ b/packages/pack/config_schema.json
@@ -1628,6 +1628,7 @@
     "SchemaReactCompilerTarget": {
       "type": "string",
       "enum": [
+        "17",
         "18",
         "19"
       ]


### PR DESCRIPTION
## Summary

Accept `reactCompiler: { target: "17" }` in the TypeScript API, Rust configuration, and generated JSON Schema. The existing compiler dependency already supports React 17, but utoo's target enum previously rejected it. React 19 remains the default; React 17/18 applications must install `react-compiler-runtime` as a runtime dependency.

Pin the next.js submodule to merged commit `3409f1882aa5ea8b3ddc70b32ae590277a9d2bb1` from https://github.com/utooland/next.js/pull/189. Its source tree is identical to the previously tested compiler commit. Add a React 17 bundler snapshot that verifies the standalone runtime import and generated memoization, while retaining the existing default React 19 snapshot.

## Test Plan

- `cargo fmt` and `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings --no-deps`
- `cargo run -p pack-schema`
- `cargo test -p pack-tests --test snapshot react_compiler`
- `tsc -p packages/pack-shared/tsconfig.json --noEmit`
- `tombi format --check`, `biome ci`, and `typos`
